### PR TITLE
[discord] cherry-pick "[LA] Add check if view is mounted on Android software-mansion#8083"

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -406,7 +406,35 @@ void LayoutAnimationsProxy::addOngoingAnimations(
     SurfaceId surfaceId,
     ShadowViewMutationList &mutations) const {
   auto &updateMap = surfaceManager.getUpdateMap(surfaceId);
+#ifdef ANDROID
+  std::vector<int> tagsToUpdate;
   for (auto &[tag, updateValues] : updateMap) {
+    tagsToUpdate.push_back(tag);
+  }
+
+  auto maybeCorrectedTags = preserveMountedTags_(tagsToUpdate);
+  if (!maybeCorrectedTags.has_value()) {
+    return;
+  }
+
+  auto correctedTags = maybeCorrectedTags->get();
+
+  // since the map is not updated, we can assume that the ordering of tags in
+  // correctedTags matches the iterator
+  int i = -1;
+#endif
+  for (auto &[tag, updateValues] : updateMap) {
+#ifdef ANDROID
+    i++;
+    if (correctedTags[i] == -1) {
+      // skip views that have not been mounted yet
+      // on Android we start entering animations from the JS thread
+      // so it might happen, that the first frame of the animation goes through
+      // before the view is first mounted
+      // https://github.com/software-mansion/react-native-reanimated/issues/7493
+      continue;
+    }
+#endif
     auto layoutAnimationIt = layoutAnimations_.find(tag);
 
     if (layoutAnimationIt == layoutAnimations_.end()) {
@@ -414,6 +442,7 @@ void LayoutAnimationsProxy::addOngoingAnimations(
     }
 
     auto &layoutAnimation = layoutAnimationIt->second;
+    layoutAnimation.opacity.reset();
 
     auto newView = std::make_shared<ShadowView>(*layoutAnimation.finalView);
     newView->props = updateValues.newProps;
@@ -866,7 +895,6 @@ void LayoutAnimationsProxy::maybeRestoreOpacity(
   if (layoutAnimation.opacity && !newStyle.hasProperty(uiRuntime_, "opacity")) {
     newStyle.setProperty(
         uiRuntime_, "opacity", jsi::Value(*layoutAnimation.opacity));
-    layoutAnimation.opacity.reset();
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.h
@@ -4,6 +4,7 @@
 #include <reanimated/Fabric/PropsRegistry.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsManager.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsUtils.h>
+#include <reanimated/Tools/PlatformDepMethodsHolder.h>
 
 #include <worklets/Tools/UIScheduler.h>
 
@@ -50,17 +51,30 @@ struct LayoutAnimationsProxy
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   jsi::Runtime &uiRuntime_;
   const std::shared_ptr<UIScheduler> uiScheduler_;
+  PreserveMountedTagsFunction preserveMountedTags_;
+
   LayoutAnimationsProxy(
       std::shared_ptr<LayoutAnimationsManager> layoutAnimationsManager,
       SharedComponentDescriptorRegistry componentDescriptorRegistry,
       ContextContainer::Shared contextContainer,
       jsi::Runtime &uiRuntime,
-      const std::shared_ptr<UIScheduler> uiScheduler)
+      const std::shared_ptr<UIScheduler> uiScheduler
+#ifdef ANDROID
+      ,
+      PreserveMountedTagsFunction filterUnmountedTagsFunction
+#endif
+      )
       : layoutAnimationsManager_(layoutAnimationsManager),
         contextContainer_(contextContainer),
         componentDescriptorRegistry_(componentDescriptorRegistry),
         uiRuntime_(uiRuntime),
-        uiScheduler_(uiScheduler) {}
+        uiScheduler_(uiScheduler)
+#ifdef ANDROID
+        ,
+        preserveMountedTags_(filterUnmountedTagsFunction)
+#endif
+  {
+  }
 
   void startEnteringAnimation(const int tag, ShadowViewMutation &mutation)
       const;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -69,6 +69,8 @@ ReanimatedModuleProxy::ReanimatedModuleProxy(
       propsRegistry_(std::make_shared<PropsRegistry>()),
       synchronouslyUpdateUIPropsFunction_(
               platformDepMethodsHolder.synchronouslyUpdateUIPropsFunction),
+      filterUnmountedTagsFunction_(
+              platformDepMethodsHolder.filterUnmountedTagsFunction),
 #else
       obtainPropFunction_(platformDepMethodsHolder.obtainPropFunction),
       configurePropsPlatformFunction_(
@@ -983,7 +985,12 @@ void ReanimatedModuleProxy::initializeLayoutAnimationsProxy() {
         componentDescriptorRegistry,
         scheduler->getContextContainer(),
         uiWorkletRuntime_->getJSIRuntime(),
-        workletsModuleProxy_->getUIScheduler());
+        workletsModuleProxy_->getUIScheduler()
+#ifdef ANDROID
+            ,
+        filterUnmountedTagsFunction_
+#endif
+    );
   }
 }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -241,6 +241,7 @@ class ReanimatedModuleProxy
   std::vector<Tag> tagsToRemove_; // from `propsRegistry_`
 
   const SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction_;
+  const PreserveMountedTagsFunction filterUnmountedTagsFunction_;
   std::unordered_set<std::string> nativePropNames_; // filled by configureProps
 #else
   const ObtainPropFunction obtainPropFunction_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Tools/PlatformDepMethodsHolder.h
@@ -7,6 +7,7 @@
 #include <react/renderer/core/ReactPrimitives.h>
 #endif
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -23,6 +24,8 @@ namespace reanimated {
 
 using SynchronouslyUpdateUIPropsFunction =
     std::function<void(Tag tag, const folly::dynamic &props)>;
+using PreserveMountedTagsFunction =
+    std::function<std::optional<std::unique_ptr<int[]>>(std::vector<int> &)>;
 using UpdatePropsFunction =
     std::function<void(jsi::Runtime &rt, const jsi::Value &operations)>;
 using ObtainPropFunction = std::function<jsi::Value(
@@ -78,6 +81,7 @@ using MaybeFlushUIUpdatesQueueFunction = std::function<void()>;
 struct PlatformDepMethodsHolder {
   RequestRenderFunction requestRender;
 #ifdef RCT_NEW_ARCH_ENABLED
+  PreserveMountedTagsFunction filterUnmountedTagsFunction;
   SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction;
 #else
   UpdatePropsFunction updatePropsFunction;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -182,6 +182,8 @@ class NativeProxy : public jni::HybridClass<NativeProxy>,
 #endif // RCT_NEW_ARCH_ENABLED
   void installJSIBindings();
 #ifdef RCT_NEW_ARCH_ENABLED
+  std::optional<std::unique_ptr<int[]>> preserveMountedTags(
+      std::vector<int> &tags);
   void synchronouslyUpdateUIProps(Tag viewTag, const folly::dynamic &props);
 #endif
   PlatformDepMethodsHolder getPlatformDependentMethods();

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -476,6 +476,20 @@ public class NodesManager implements EventDispatcherListener {
     }
   }
 
+  public boolean preserveMountedTags(int[] tags) {
+    if (!UiThreadUtil.isOnUiThread()) {
+      return false;
+    }
+
+    for (int i = 0; i < tags.length; i++) {
+      if (mUIManager.resolveView(tags[i]) == null) {
+        tags[i] = -1;
+      }
+    }
+
+    return true;
+  }
+
   public void synchronouslyUpdateUIProps(int viewTag, ReadableMap uiProps) {
     compatibility.synchronouslyUpdateUIProps(viewTag, uiProps);
   }

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
@@ -130,6 +130,11 @@ public abstract class NativeProxyCommon {
   }
 
   @DoNotStrip
+  public boolean preserveMountedTags(int[] tags) {
+    return mNodesManager.preserveMountedTags(tags);
+  }
+
+  @DoNotStrip
   public void synchronouslyUpdateUIProps(int viewTag, ReadableMap uiProps) {
     mNodesManager.synchronouslyUpdateUIProps(viewTag, uiProps);
   }


### PR DESCRIPTION
Was mostly a clean cherry-pick onto our version of 3.17.4.  Main difference is that the original v4 version operated on `mFabricUIManager.resolveView`, whereas here I had to update to `NativeProxyCommon.java` to call into `NodeManager` to call `mUIManager.resolveView`.