### PR TITLE
fix(reanimated): workaround for react-freeze unmounting class compone…

### DIFF
--- a/packages/react-native-reanimated/src/updateProps/ComponentRegistry.ts
+++ b/packages/react-native-reanimated/src/updateProps/ComponentRegistry.ts
@@ -1,12 +1,21 @@
 import type { IAnimatedComponentInternal } from '../createAnimatedComponent/commonTypes';
 
-// Registry to map component tags to component instancesAdd commentMore actions
+// Registry to map component tags to component instances
 const componentRegistry = new Map<number | HTMLElement, IAnimatedComponentInternal>();
+// Cache for delayed updates when components aren't found
+const pendingUpdates = new Map<number | HTMLElement, any>();
 
 export const ComponentRegistry = {
   // Register a component instance with its tag
   register: (tag: number | HTMLElement, component: IAnimatedComponentInternal) => {
     componentRegistry.set(tag, component);
+
+    // Check if there are pending updates for this tag
+    const pendingUpdate = pendingUpdates.get(tag);
+    if (pendingUpdate) {
+      component._updateReanimatedProps(pendingUpdate);
+      pendingUpdates.delete(tag);
+    }
   },
 
   // Unregister a component
@@ -17,5 +26,10 @@ export const ComponentRegistry = {
   // Get a component for a tag
   getComponent: (tag: number | HTMLElement): IAnimatedComponentInternal | undefined => {
     return componentRegistry.get(tag);
+  },
+
+  // Cache an update for when component becomes available
+  cacheUpdate: (tag: number | HTMLElement, props: any) => {
+    pendingUpdates.set(tag, props);
   }
 };

--- a/packages/react-native-reanimated/src/updateProps/updateProps.ts
+++ b/packages/react-native-reanimated/src/updateProps/updateProps.ts
@@ -80,6 +80,8 @@ function updatePropsOnReactJS(tag: number, props: StyleProps) {
   const component = ComponentRegistry.getComponent(tag);
   if (component) {
     component._updateReanimatedProps(props);
+  } else { // if component is not found, cache the update (i.e component was frozen)
+    ComponentRegistry.cacheUpdate(tag, props);
   }
 }
 


### PR DESCRIPTION
## Problem

When users enable reduced motion accessibility settings on Android, swiping to channels shows a gray screen instead of the expected content. This occurs because:

1. **Reduced motion** causes animations to complete instantly
2. **react-freeze** suspends screens using React Suspense
3. **React Suspense unmounts class components** (but not functional components) when suspended
4. **Reanimated's delayed updates** arrive after components are unmounted, causing them to fail
5. **Remounted components** have different view tags, so cached updates are lost

## Root Cause

This is a known React behavior where `react-freeze` (which uses React Suspense) unmounts class components but not functional components. This inconsistency causes Reanimated's class-based `AnimatedComponent` to lose its registration in the component registry during freeze cycles.

## Solution

Implemented a **cached updates workaround** that:

- **Caches delayed updates** when components are not found in the registry
- **Applies cached updates** when components remount after freeze/unfreeze
- **Prevents race conditions** by ensuring latest cached update overwrites previous ones
- **Maintains state consistency** during React Suspense freeze cycles

## Changes

- Added `pendingUpdates` cache in `ComponentRegistry`
- Modified `updatePropsOnReactJS` to cache updates when component not found
- Apply cached updates in `register()` when components remount

## Note

This is a **workaround** for React's inconsistent Suspense behavior between class and functional components. The proper fix would require React to have consistent behavior between class and functional components under Suspense (react-freeze).

## References

- [React Issue #25732](https://github.com/facebook/react/issues/25732) - Suspense unmounts class components but not functional components
- [react-freeze](https://github.com/software-mansion/react-freeze) - Uses React Suspense internally

ticket: https://app.asana.com/1/236888843494340/project/1211431490980643/task/1211215533034093?focus=true