### PR TITLE
(cherry-pick) fix: Animated styles not registered after unfreeze (#8325)

### DIFF
--- a/packages/react-native-reanimated/src/ViewDescriptorsSet.ts
+++ b/packages/react-native-reanimated/src/ViewDescriptorsSet.ts
@@ -7,13 +7,17 @@ export interface ViewDescriptorsSet {
   shareableViewDescriptors: SharedValue<Descriptor[]>;
   add: (item: Descriptor) => void;
   remove: (viewTag: number) => void;
+  has: (viewTag: number) => boolean;
 }
 
 export function makeViewDescriptorsSet(): ViewDescriptorsSet {
   const shareableViewDescriptors = makeMutable<Descriptor[]>([]);
+  const viewTags = new Set<number>();
+
   const data: ViewDescriptorsSet = {
     shareableViewDescriptors,
     add: (item: Descriptor) => {
+      viewTags.add(item.tag as number);
       shareableViewDescriptors.modify((descriptors) => {
         'worklet';
         const index = descriptors.findIndex(
@@ -29,6 +33,7 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
     },
 
     remove: (viewTag: number) => {
+      viewTags.delete(viewTag);
       shareableViewDescriptors.modify((descriptors) => {
         'worklet';
         const index = descriptors.findIndex(
@@ -40,6 +45,9 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
         return descriptors;
       }, false);
     },
+
+    has: (viewTag: number) => viewTags.has(viewTag),
   };
+
   return data;
 }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -432,6 +432,9 @@ export function createAnimatedComponent(
         adaptViewConfig(viewConfig);
       }
 
+      const isStyleAttached = (style: StyleProps) =>
+        style.viewDescriptors.has(viewTag);
+
       // remove old styles
       if (prevStyles) {
         // in most of the cases, views have only a single animated style and it remains unchanged
@@ -440,13 +443,21 @@ export function createAnimatedComponent(
           prevStyles.length === 1 &&
           styles[0] === prevStyles[0];
 
-        if (!hasOneSameStyle) {
-          // otherwise, remove each style that is not present in new styles
-          for (const prevStyle of prevStyles) {
-            const isPresent = styles.some((style) => style === prevStyle);
-            if (!isPresent) {
-              prevStyle.viewDescriptors.remove(viewTag);
+        if (hasOneSameStyle && isStyleAttached(prevStyles[0])) {
+          return;
+        }
+
+        // otherwise, remove each style that is not present in new styles
+        for (const prevStyle of prevStyles) {
+          const isPresent = styles.some((style) => {
+            if (style === prevStyle && isStyleAttached(style)) {
+              // Skip already attached styles
+              return true;
             }
+            return false;
+          });
+          if (!isPresent) {
+            prevStyle.viewDescriptors.remove(viewTag);
           }
         }
       }


### PR DESCRIPTION
Cherry pick of https://github.com/software-mansion/react-native-reanimated/pull/8325

This PR fixes animated styles registering on freeze/unfreeze. The issue was caused by the cleanup made in the `componentWillUnmount`, which removes the current view tag from the animated style's view descriptors. This view tag was never added later on because only the style object references were compared and, because the style prop didn't change between freeze/unfreeze, we assumed that there is no need to register the animated styles again. This assumption was correct as long as the `componentWillUnmount` was executed before the component was actually unmounted (but, it turns out that this method is also called when the component is frozen, not unmounted).

The pink rectangle with the animated style attached didn't animate after navigating back to the previously frozen screen.

| Before | After |
|-|-|
| <video
src="https://github.com/user-attachments/assets/eaaa21ae-266a-4649-8fb3-b492e80fc186" /> | <video
src="https://github.com/user-attachments/assets/744eb171-d231-49aa-92f2-e89174dd2b15" /> |

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
