### PR TITLE
feat(reanimated): prevent style detachment for components frozen by S…

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.cpp
@@ -1,6 +1,7 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/Fabric/PropsRegistry.h>
+#include <cstring>
 
 namespace reanimated {
 
@@ -41,18 +42,43 @@ void PropsRegistry::unmarkNodeAsRemovable(Tag viewTag) {
   removableShadowNodes_.erase(viewTag);
 }
 
-void PropsRegistry::handleNodeRemovals(const RootShadowNode &rootShadowNode) {
+void PropsRegistry::handleNodeRemovals(
+    const RootShadowNode &rootShadowNode,
+    const NodeRemovalCallback &callback) {
   RemovableShadowNodes remainingShadowNodes;
 
   for (const auto &[tag, shadowNode] : removableShadowNodes_) {
     if (!shadowNode) {
+      // Stopgap for bad shadowNode
+      map_.erase(tag);
       continue;
     }
 
-    if (shadowNode->getFamily().getAncestors(rootShadowNode).empty()) {
-      map_.erase(tag);
-    } else {
+    const auto &family = shadowNode->getFamily();
+    const auto &ancestors = family.getAncestors(rootShadowNode);
+
+    // Determine if component is frozen
+    // isFrozen=true means component still has parents (with Suspense parent being one of them)
+    // isFrozen=false means component is truly unmounting
+    bool isFrozen = false;
+    for (const auto &[parentNode, _] : ancestors) {
+      const auto parentComponentName = parentNode.get().getComponentName();
+      if (strstr(parentComponentName, "Suspense") != nullptr) {
+        isFrozen = true;
+        break;
+      }
+    }
+
+    // Notify JavaScript about the freeze decision
+    if (callback) {
+      callback(tag, isFrozen);
+    }
+
+    // PropsRegistry decision: keep if has ancestors, remove if no ancestors
+    if (!ancestors.empty()) {
       remainingShadowNodes.emplace(tag, shadowNode);
+    } else {
+      map_.erase(tag);
     }
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h
@@ -13,6 +13,8 @@ using namespace react;
 
 namespace reanimated {
 
+using NodeRemovalCallback = std::function<void(Tag tag, bool isFrozen)>;
+
 class PropsRegistry {
  public:
   std::lock_guard<std::mutex> createLock() const;
@@ -54,7 +56,9 @@ class PropsRegistry {
 
   void markNodeAsRemovable(const std::shared_ptr<const ShadowNode> &shadowNode);
   void unmarkNodeAsRemovable(Tag viewTag);
-  void handleNodeRemovals(const RootShadowNode &rootShadowNode);
+  void handleNodeRemovals(
+      const RootShadowNode &rootShadowNode,
+      const NodeRemovalCallback &callback = nullptr);
 
   // Custom discord added for removing nodes once they seem in sync with the shadow tree
   void markNodeAsImmediateRemovable(Tag tag);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -2,13 +2,15 @@
 
 #include <reanimated/Fabric/ReanimatedCommitShadowNode.h>
 #include <reanimated/Fabric/ReanimatedMountHook.h>
+#include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 
 namespace reanimated {
 
 ReanimatedMountHook::ReanimatedMountHook(
     const std::shared_ptr<PropsRegistry> &propsRegistry,
-    const std::shared_ptr<UIManager> &uiManager)
-    : propsRegistry_(propsRegistry), uiManager_(uiManager) {
+    const std::shared_ptr<UIManager> &uiManager,
+    const std::shared_ptr<ReanimatedModuleProxy> &moduleProxy)
+    : propsRegistry_(propsRegistry), uiManager_(uiManager), moduleProxy_(moduleProxy) {
   uiManager_->registerMountHook(*this);
 }
 
@@ -40,7 +42,14 @@ void ReanimatedMountHook::shadowTreeDidMount(
 
   {
     auto lock = propsRegistry_->createLock();
-    propsRegistry_->handleNodeRemovals(*rootShadowNode);
+
+    // Create callback to notify JavaScript about node removal decisions
+    auto callback = [this](Tag tag, bool isFrozen) {
+      if (moduleProxy_) {
+        moduleProxy_->onNodeRemovalDecision(tag, isFrozen);
+      }
+    };
+    propsRegistry_->handleNodeRemovals(*rootShadowNode, callback);
 
     // When commit from React Native has finished, we reset the skip commit flag
     // in order to allow Reanimated to commit its tree

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -45,8 +45,9 @@ void ReanimatedMountHook::shadowTreeDidMount(
 
     // Create callback to notify JavaScript about node removal decisions
     auto callback = [this](Tag tag, bool isFrozen) {
-      if (moduleProxy_) {
-        moduleProxy_->onNodeRemovalDecision(tag, isFrozen);
+      auto moduleProxy = moduleProxy_.lock();
+      if (moduleProxy) {
+        moduleProxy->onNodeRemovalDecision(tag, isFrozen);
       }
     };
     propsRegistry_->handleNodeRemovals(*rootShadowNode, callback);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
@@ -35,7 +35,7 @@ class ReanimatedMountHook : public UIManagerMountHook {
  private:
   const std::shared_ptr<PropsRegistry> propsRegistry_;
   const std::shared_ptr<UIManager> uiManager_;
-  const std::shared_ptr<ReanimatedModuleProxy> moduleProxy_;
+  const std::weak_ptr<ReanimatedModuleProxy> moduleProxy_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
@@ -12,11 +12,15 @@ namespace reanimated {
 
 using namespace facebook::react;
 
+// Forward declaration
+class ReanimatedModuleProxy;
+
 class ReanimatedMountHook : public UIManagerMountHook {
  public:
   ReanimatedMountHook(
       const std::shared_ptr<PropsRegistry> &propsRegistry,
-      const std::shared_ptr<UIManager> &uiManager);
+      const std::shared_ptr<UIManager> &uiManager,
+      const std::shared_ptr<ReanimatedModuleProxy> &moduleProxy);
   ~ReanimatedMountHook() noexcept override;
 
   void shadowTreeDidMount(
@@ -31,6 +35,7 @@ class ReanimatedMountHook : public UIManagerMountHook {
  private:
   const std::shared_ptr<PropsRegistry> propsRegistry_;
   const std::shared_ptr<UIManager> uiManager_;
+  const std::shared_ptr<ReanimatedModuleProxy> moduleProxy_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1068,22 +1068,18 @@ void ReanimatedModuleProxy::setNodeRemovalCallback(
     jsi::Runtime &rt,
     const jsi::Value &callback) {
   if (callback.isObject() && callback.asObject(rt).isFunction(rt)) {
-    nodeRemovalCallback_ = std::make_shared<jsi::Function>(
-        callback.asObject(rt).asFunction(rt));
+    nodeRemovalCallback_ = react::AsyncCallback<>(
+        rt,
+        callback.asObject(rt).asFunction(rt),
+        jsInvoker_);
   }
 }
 
 void ReanimatedModuleProxy::onNodeRemovalDecision(Tag tag, bool isFrozen) {
   if (nodeRemovalCallback_) {
-    auto callback = nodeRemovalCallback_;
-
-    // Must invoke on JS thread to avoid crashes
-    jsInvoker_->invokeAsync([callback, tag, isFrozen](jsi::Runtime& rt) {
-      if (callback) {
-        callback->call(rt,
-                       jsi::Value(static_cast<double>(tag)),
-                       jsi::Value(isFrozen));
-      }
+    // Use custom lambda to manually convert to JSI values (JSI supports int/bool via jsi::Value)
+    nodeRemovalCallback_->call([tag, isFrozen](jsi::Runtime& rt, jsi::Function& callback) {
+      callback.call(rt, jsi::Value(static_cast<int>(tag)), jsi::Value(isFrozen));
     });
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -978,7 +978,7 @@ void ReanimatedModuleProxy::initializeFabric(
   initializeLayoutAnimationsProxy();
 
   mountHook_ =
-      std::make_shared<ReanimatedMountHook>(propsRegistry_, uiManager_);
+      std::make_shared<ReanimatedMountHook>(propsRegistry_, uiManager_, shared_from_this());
   commitHook_ = std::make_shared<ReanimatedCommitHook>(
       propsRegistry_, uiManager_, layoutAnimationsProxy_);
 }
@@ -1062,5 +1062,34 @@ void ReanimatedModuleProxy::unsubscribeFromKeyboardEvents(
     const jsi::Value &listenerId) {
   unsubscribeFromKeyboardEventsFunction_(listenerId.asNumber());
 }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+void ReanimatedModuleProxy::setNodeRemovalCallback(
+    jsi::Runtime &rt,
+    const jsi::Value &callback) {
+  if (callback.isObject() && callback.asObject(rt).isFunction(rt)) {
+    nodeRemovalCallback_ = std::make_shared<jsi::Function>(
+        callback.asObject(rt).asFunction(rt));
+    nodeRemovalCallbackRuntime_ = &rt;
+  }
+}
+
+void ReanimatedModuleProxy::onNodeRemovalDecision(Tag tag, bool isFrozen) {
+  if (nodeRemovalCallback_ && nodeRemovalCallbackRuntime_) {
+    // Capture callback and runtime by value to ensure they're still valid
+    auto callback = nodeRemovalCallback_;
+    auto runtime = nodeRemovalCallbackRuntime_;
+
+    // Must invoke on JS thread to avoid crashes
+    jsInvoker_->invokeAsync([callback, runtime, tag, isFrozen]() {
+      if (callback && runtime) {
+        callback->call(*runtime,
+                       jsi::Value(static_cast<double>(tag)),
+                       jsi::Value(isFrozen));
+      }
+    });
+  }
+}
+#endif // RCT_NEW_ARCH_ENABLED
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1070,20 +1070,17 @@ void ReanimatedModuleProxy::setNodeRemovalCallback(
   if (callback.isObject() && callback.asObject(rt).isFunction(rt)) {
     nodeRemovalCallback_ = std::make_shared<jsi::Function>(
         callback.asObject(rt).asFunction(rt));
-    nodeRemovalCallbackRuntime_ = &rt;
   }
 }
 
 void ReanimatedModuleProxy::onNodeRemovalDecision(Tag tag, bool isFrozen) {
-  if (nodeRemovalCallback_ && nodeRemovalCallbackRuntime_) {
-    // Capture callback and runtime by value to ensure they're still valid
+  if (nodeRemovalCallback_) {
     auto callback = nodeRemovalCallback_;
-    auto runtime = nodeRemovalCallbackRuntime_;
 
     // Must invoke on JS thread to avoid crashes
-    jsInvoker_->invokeAsync([callback, runtime, tag, isFrozen]() {
-      if (callback && runtime) {
-        callback->call(*runtime,
+    jsInvoker_->invokeAsync([callback, tag, isFrozen](jsi::Runtime& rt) {
+      if (callback) {
+        callback->call(rt,
                        jsi::Value(static_cast<double>(tag)),
                        jsi::Value(isFrozen));
       }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -131,6 +131,10 @@ class ReanimatedModuleProxy
   void unmarkNodeAsRemovable(jsi::Runtime &rt, const jsi::Value &viewTag)
       override;
 
+  void setNodeRemovalCallback(jsi::Runtime &rt, const jsi::Value &callback)
+      override;
+  void onNodeRemovalDecision(Tag tag, bool isFrozen);
+
   void dispatchCommand(
       jsi::Runtime &rt,
       const jsi::Value &shadowNodeValue,
@@ -246,6 +250,10 @@ class ReanimatedModuleProxy
 
   const SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction_;
   std::unordered_set<std::string> nativePropNames_; // filled by configureProps
+
+  // Node removal callback for freeze detection
+  std::shared_ptr<jsi::Function> nodeRemovalCallback_;
+  jsi::Runtime* nodeRemovalCallbackRuntime_ = nullptr;
 #else
   const ObtainPropFunction obtainPropFunction_;
   const ConfigurePropsFunction configurePropsPlatformFunction_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -10,6 +10,7 @@
 #include <reanimated/Fabric/ReanimatedCommitHook.h>
 #include <reanimated/Fabric/ReanimatedMountHook.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy.h>
+#include <react/bridging/Function.h>
 #endif // RCT_NEW_ARCH_ENABLED
 
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
@@ -252,7 +253,7 @@ class ReanimatedModuleProxy
   std::unordered_set<std::string> nativePropNames_; // filled by configureProps
 
   // Node removal callback for freeze detection
-  std::shared_ptr<jsi::Function> nodeRemovalCallback_;
+  std::optional<react::AsyncCallback<>> nodeRemovalCallback_;
 #else
   const ObtainPropFunction obtainPropFunction_;
   const ConfigurePropsFunction configurePropsPlatformFunction_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -253,7 +253,6 @@ class ReanimatedModuleProxy
 
   // Node removal callback for freeze detection
   std::shared_ptr<jsi::Function> nodeRemovalCallback_;
-  jsi::Runtime* nodeRemovalCallbackRuntime_ = nullptr;
 #else
   const ObtainPropFunction obtainPropFunction_;
   const ConfigurePropsFunction configurePropsPlatformFunction_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
@@ -182,6 +182,16 @@ static jsi::Value REANIMATED_SPEC_PREFIX(unmarkNodeAsRemovable)(
   return jsi::Value::undefined();
 }
 
+static jsi::Value REANIMATED_SPEC_PREFIX(setNodeRemovalCallback)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t) {
+  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
+      ->setNodeRemovalCallback(rt, std::move(args[0]));
+  return jsi::Value::undefined();
+}
+
 #endif // RCT_NEW_ARCH_ENABLED
 
 ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
@@ -226,6 +236,8 @@ ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
       MethodMetadata{1, REANIMATED_SPEC_PREFIX(markNodeAsRemovable)};
   methodMap_["unmarkNodeAsRemovable"] =
       MethodMetadata{1, REANIMATED_SPEC_PREFIX(unmarkNodeAsRemovable)};
+  methodMap_["setNodeRemovalCallback"] =
+      MethodMetadata{1, REANIMATED_SPEC_PREFIX(setNodeRemovalCallback)};
 #endif // RCT_NEW_ARCH_ENABLED
 }
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
@@ -103,6 +103,9 @@ class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
   virtual void unmarkNodeAsRemovable(
       jsi::Runtime &rt,
       const jsi::Value &viewTag) = 0;
+  virtual void setNodeRemovalCallback(
+      jsi::Runtime &rt,
+      const jsi::Value &callback) = 0;
 #endif // RCT_NEW_ARCH_ENABLED
 };
 

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -197,6 +197,10 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
   unmarkNodeAsRemovable(viewTag: number) {
     this.#reanimatedModuleProxy.unmarkNodeAsRemovable(viewTag);
   }
+
+  setNodeRemovalCallback(callback: (tag: number, isFrozen: boolean) => void) {
+    this.#reanimatedModuleProxy.setNodeRemovalCallback(callback);
+  }
 }
 
 class DummyReanimatedModuleProxy implements ReanimatedModuleProxy {
@@ -221,6 +225,7 @@ class DummyReanimatedModuleProxy implements ReanimatedModuleProxy {
   unsubscribeFromKeyboardEvents(): void {}
   markNodeAsRemovable(): void {}
   unmarkNodeAsRemovable(): void {}
+  setNodeRemovalCallback(): void {}
 
   registerSensor(): number {
     return -1;

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -312,6 +312,14 @@ class JSReanimated implements IReanimatedModule {
       'unmarkNodeAsRemovable is not available in JSReanimated.'
     );
   }
+
+  setNodeRemovalCallback(
+    _callback: (tag: number, isFrozen: boolean) => void
+  ): void {
+    throw new ReanimatedError(
+      'setNodeRemovalCallback is not available in JSReanimated.'
+    );
+  }
 }
 
 // Lack of this export breaks TypeScript generation since

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -69,4 +69,8 @@ export interface ReanimatedModuleProxy {
 
   markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper): void;
   unmarkNodeAsRemovable(viewTag: number): void;
+
+  setNodeRemovalCallback(
+    callback: (tag: number, isFrozen: boolean) => void
+  ): void;
 }

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -230,3 +230,11 @@ export function markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper) {
 export function unmarkNodeAsRemovable(viewTag: number) {
   ReanimatedModule.unmarkNodeAsRemovable(viewTag);
 }
+
+export function setNodeRemovalCallback(
+  callback: (tag: number, isFrozen: boolean) => void
+) {
+  if (isFabric()) {
+    ReanimatedModule.setNodeRemovalCallback(callback);
+  }
+}

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -128,13 +128,19 @@ export interface IAnimatedComponentInternal {
   _NativeEventsManager?: INativeEventsManager;
   _viewInfo?: ViewInfo;
   context: React.ContextType<typeof SkipEnteringContext>;
+  _willUnmount: boolean;
   /**
    * Used for Shared Element Transitions, Layout Animations and Animated Styles.
    * It is not related to event handling.
    */
   getComponentViewTag: () => number;
-  /** A function that will update the components state (the state is used for the style prop) */
+  /**
+   * A function that will update the components state (the state is used for the
+   * style prop)
+   */
   _updateReanimatedProps: (props: StyleProps) => void;
+  /** Detach styles from view descriptors */
+  _detachStyles: () => void;
 }
 
 export type NestedArray<T> = T | NestedArray<T>[];

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -24,6 +24,7 @@ import { adaptViewConfig } from '../ConfigHelper';
 import {
   enableLayoutAnimations,
   markNodeAsRemovable,
+  setNodeRemovalCallback,
   unmarkNodeAsRemovable,
 } from '../core';
 import { ReanimatedError } from '../errors';
@@ -52,6 +53,7 @@ import {
 import { componentWithRef } from '../reactUtils';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
 import { updateLayoutAnimations } from '../UpdateLayoutAnimations';
+import { ComponentRegistry } from '../updateProps/ComponentRegistry';
 import type {
   AnimatedComponentProps,
   AnimatedComponentRef,
@@ -70,7 +72,6 @@ import { NativeEventsManager } from './NativeEventsManager';
 import { PropsFilter } from './PropsFilter';
 import setAndForwardRef from './setAndForwardRef';
 import { flattenArray } from './utils';
-import { ComponentRegistry } from '../updateProps/ComponentRegistry';
 
 const IS_WEB = isWeb();
 const IS_JEST = isJest();
@@ -81,6 +82,27 @@ if (IS_WEB) {
   configureWebLayoutAnimations();
 }
 
+// Register callback for freeze detection (Fabric only)
+// Extends PR #7316's markNodeAsRemovable infrastructure with Suspense-based freeze detection
+if (isFabric()) {
+  setNodeRemovalCallback((tag: number, isFrozen: boolean) => {
+    const component = ComponentRegistry.getComponent(tag);
+    if (!component || !component._willUnmount) {
+      // Skip if component doesn't exist or already handled (remounted before callback fired)
+      return;
+    }
+
+    if (!isFrozen) {
+      // Component truly unmounted - safe to clean up
+      component._detachStyles();
+      ComponentRegistry.unregister(tag);
+    }
+
+    // Always clear flag whether frozen or unmounted
+    component._willUnmount = false;
+  });
+}
+
 function onlyAnimatedStyles(styles: StyleProps[]): StyleProps[] {
   return styles.filter((style) => style?.viewDescriptors);
 }
@@ -88,9 +110,9 @@ function onlyAnimatedStyles(styles: StyleProps[]): StyleProps[] {
 type Options<P> = {
   setNativeProps?: (ref: AnimatedComponentRef, props: P) => void;
   /**
-   * Discord enables a performance improvement, which causes us to sync back any animated props from the UI thread
-   * back to react JS.
-   * Switching this to `true` disables this behavior. Default is `false`.
+   * Discord enables a performance improvement, which causes us to sync back any
+   * animated props from the UI thread back to react JS. Switching this to
+   * `true` disables this behavior. Default is `false`.
    */
   disableReactSync?: boolean;
 };
@@ -128,7 +150,7 @@ export function createAnimatedComponent<P extends object>(
 // @ts-ignore This is required to create this overload, since type of createAnimatedComponent is incorrect and doesn't include typeof FlatList
 export function createAnimatedComponent(
   component: typeof FlatList<unknown>,
-  options?: Options<any>
+  options?: Options<FlatListProps<unknown>>
 ): ComponentClass<AnimateProps<FlatListProps<unknown>>>;
 
 let id = 0;
@@ -136,7 +158,9 @@ let id = 0;
 export function createAnimatedComponent(
   Component: ComponentType<InitialComponentProps>,
   options?: Options<InitialComponentProps>
-): any {
+):
+  | FunctionComponent<AnimateProps<InitialComponentProps>>
+  | ComponentClass<AnimateProps<InitialComponentProps>> {
   if (!IS_REACT_19) {
     invariant(
       typeof Component !== 'function' ||
@@ -146,7 +170,10 @@ export function createAnimatedComponent(
   }
 
   class AnimatedComponent
-    extends React.Component<AnimatedComponentProps<InitialComponentProps>, { reanimatedProps: {[key: string]: unknown}; }>
+    extends React.Component<
+      AnimatedComponentProps<InitialComponentProps>,
+      { reanimatedProps: { [key: string]: unknown } }
+    >
     implements IAnimatedComponentInternal
   {
     _styles: StyleProps[] | null = null;
@@ -180,9 +207,8 @@ export function createAnimatedComponent(
 
       this.state = {
         reanimatedProps: {},
-      }
+      };
 
-      const entering = this.props.entering;
       const skipEntering = this.context?.current;
       if (isFabric() && !skipEntering) {
         this._configureLayoutAnimation(
@@ -252,6 +278,8 @@ export function createAnimatedComponent(
         this._willUnmount &&
         typeof viewTag === 'number'
       ) {
+        // Component was frozen and is now remounting - cancel pending cleanup
+        this._willUnmount = false;
         unmarkNodeAsRemovable(viewTag);
       }
 
@@ -261,7 +289,18 @@ export function createAnimatedComponent(
     componentWillUnmount() {
       this._NativeEventsManager?.detachEvents();
       this._jsPropsUpdater.removeOnJSPropsChangeListener(this);
-      this._detachStyles();
+
+      const viewTag = this.getComponentViewTag();
+
+      // Defer cleanup for Fabric (freeze detection via callback), immediate for Paper/Web
+      if (!SHOULD_BE_USE_WEB && isFabric()) {
+        // Mark as unmounting - callback will determine if frozen or truly unmounted
+        this._willUnmount = true;
+      } else {
+        // Paper/Web: Can't distinguish freeze from unmount, clean up immediately
+        this._detachStyles();
+      }
+
       this._InlinePropManager.detachInlineProps();
       if (this.props.sharedTransitionTag) {
         this._configureSharedTransition(true);
@@ -272,8 +311,9 @@ export function createAnimatedComponent(
       );
 
       const exiting = this.props.exiting;
-      const viewTag = this.getComponentViewTag();
-      if (viewTag !== -1) {
+
+      // Unregister from ComponentRegistry (Paper only - Fabric handled in callback)
+      if (!SHOULD_BE_USE_WEB && !isFabric() && viewTag !== -1) {
         ComponentRegistry.unregister(viewTag);
       }
 
@@ -308,8 +348,6 @@ export function createAnimatedComponent(
         // remounted (e.g., when frozen) after componentWillUnmount is called.
         markNodeAsRemovable(wrapper);
       }
-
-      this._willUnmount = true;
     }
 
     getComponentViewTag() {
@@ -340,25 +378,31 @@ export function createAnimatedComponent(
     }
 
     /**
-     * Mechanism to update this component's props from native.Add commentMore actions
-     * (As reanimated is changing the props only on the UI thread at some point we want to sync with the JS thread).
-     * Reanimated props can be animatedProps but also animated styles. Note that styles are flattened and passed as top level props.
+     * Mechanism to update this component's props from native.Add commentMore
+     * actions (As reanimated is changing the props only on the UI thread at
+     * some point we want to sync with the JS thread). Reanimated props can be
+     * animatedProps but also animated styles. Note that styles are flattened
+     * and passed as top level props.
      */
-    _updateReanimatedProps(props: {[key: string]: unknown}) {
+    _updateReanimatedProps(props: { [key: string]: unknown }) {
       if (options?.disableReactSync) {
         return;
       }
 
-      const transformedProps: {[key: string]: unknown} = {};
+      const transformedProps: { [key: string]: unknown } = {};
       for (const prop in props) {
         let value = props[prop];
-        if ((prop === 'color' || prop.endsWith('Color')) && value && typeof value === 'string') {
+        if (
+          (prop === 'color' || prop.endsWith('Color')) &&
+          value &&
+          typeof value === 'string'
+        ) {
           value = processColor(value);
         } else if (
-          prop == 'top'
-          || prop == 'bottom'
-          || prop.startsWith('margin')
-          || prop.startsWith('padding')
+          prop === 'top' ||
+          prop === 'bottom' ||
+          prop.startsWith('margin') ||
+          prop.startsWith('padding')
         ) {
           // if all reanimated props cannot be updated, there is no point in syncing them
           return;
@@ -396,9 +440,9 @@ export function createAnimatedComponent(
       } else {
         const hostInstance = findHostInstance(this);
         if (!hostInstance) {
-          /* 
-            findHostInstance can return null for a component that doesn't render anything 
-            (render function returns null). Example: 
+          /*
+            findHostInstance can return null for a component that doesn't render anything
+            (render function returns null). Example:
             svg Stop: https://github.com/react-native-svg/react-native-svg/blob/develop/src/elements/Stop.tsx
           */
           throw new ReanimatedError(


### PR DESCRIPTION
# Prevent style detachment for components frozen by Suspense

## Problem

When React Suspense freezes components (using `react-freeze`), `componentWillUnmount` is called but the component will be remounted later. Reanimated's current behavior detaches all styles and unregisters from `ComponentRegistry` during `componentWillUnmount`, causing issues when the component is remounted.

## Solution

Distinguish between truly unmounted components and frozen components by checking if the component still has ancestors in the shadow tree during native shadow tree operations.

## Freeze Detection Logic

The key insight is in `PropsRegistry::handleNodeRemovals`:

1. **If `ancestors.empty()`**: Component is truly unmounted (no parent in shadow tree)
2. **If ancestors exist**: Component is frozen (has parent but hidden by Suspense)

This works because:
- Suspense with `mode: "hidden"` removes children from the shadow tree but keeps them in memory
- Frozen components still have ancestors (the Suspense component itself)
- Truly unmounted components have no ancestors in the current shadow tree

The additional check for "Suspense" in the parent chain provides extra confirmation, but the presence of ancestors is the primary indicator of a frozen component.

## Implementation

### Native Side (C++)
- **PropsRegistry::handleNodeRemovals**: Check for "Suspense" in parent component names to detect frozen components
- **ReanimatedModuleProxy**: Add JSI callback mechanism to communicate freeze decisions to JavaScript
- **ReanimatedMountHook**: Wire the callback to be called during `shadowTreeDidMount`

### JavaScript Side
- **createAnimatedComponent**: Register callback to receive freeze decisions from native
- **Conditional cleanup**: Only detach styles and unregister for truly unmounted components
- **Race condition handling**: Skip cleanup if component remounts before callback fires

## Key Changes

1. **Freeze Detection**: `PropsRegistry::handleNodeRemovals` checks ancestor chain for Suspense components
2. **JSI Callback**: `setNodeRemovalCallback` allows native code to communicate with JavaScript
3. **Thread Safety**: Use `jsInvoker` to safely call JavaScript from native UI thread
4. **Conditional Logic**: Skip `_detachStyles()` and `ComponentRegistry.unregister()` for frozen components
5. **Flag Management**: Extend `_willUnmount` flag to track pending cleanup decisions



## Scope

- **Fabric only**: Paper (old architecture) doesn't suffer from this issue
- **Backward compatible**: No breaking changes to existing APIs
- **Performance**: Minimal overhead - only checks component names during mount operations

## Ticket 
https://app.asana.com/1/236888843494340/project/1211296341662376/task/1211215533034093?focus=true