### PR TITLE
fix(andorid): crash, check for IllegalViewOperationException

### DIFF
--- a/packages/react-native-reanimated/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
+import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.swmansion.reanimated.layoutReanimation.LayoutAnimations;
@@ -85,7 +86,11 @@ public class NativeProxy extends NativeProxyCommon {
     for (int i = 0; i < tags.length; i++) {
       // Note: resolveView has assertOnUiThread, which only logs as softexception in debug
       // It is actually completely thread safe and there is a RFC in RN to do something about it
-      if (mFabricUIManager.resolveView(tags[i]) == null) {
+      try {
+        if (mFabricUIManager.resolveView(tags[i]) == null) {
+          tags[i] = -1;
+        }
+      } catch (IllegalViewOperationException ex) {
         tags[i] = -1;
       }
     }


### PR DESCRIPTION
In GCP there is a new crash for latest stable:

- https://play.google.com/console/u/0/developers/6876955335863008122/app/4976344941763558507/vitals/crashes/d4c127f57e0696159037a4488063a158/details?days=28&versionCode=303010&isUserPerceived=true

It seems that `resolveView` will always throw an exception when it can't find a view:

https://github.com/facebook/react-native/blame/963f7a5c24532cdd9019911a05dc57bd57b9f095/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java#L1239

So we have to try catch that