### PR TITLE
postpone executing sync mount if triggered by event during draw pass

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -844,17 +844,17 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
   {
     auto lock = propsRegistry_->createLock();
 
-    if (copiedOperationsQueue.size() > 0 &&
-        propsRegistry_->shouldReanimatedSkipCommit()) {
-      propsRegistry_->pleaseCommitAfterPause();
-    }
-
     // remove recently unmounted ShadowNodes from PropsRegistry
     if (!tagsToRemove_.empty()) {
       for (auto tag : tagsToRemove_) {
         propsRegistry_->remove(tag);
       }
       tagsToRemove_.clear();
+    }
+
+    if (copiedOperationsQueue.size() > 0 &&
+        propsRegistry_->shouldReanimatedSkipCommit()) {
+      propsRegistry_->pleaseCommitAfterPause();
     }
 
     // Even if only non-layout props are changed, we need to store the update
@@ -915,6 +915,11 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
   }
 
   for (auto const &[surfaceId, propsMap] : propsMapBySurface) {
+    if (propsMapBySurface.size() == 0) {
+        // Avoid calling commit(sync = true), as that could force React Native to sync flush all pending mount transactions
+      continue;
+    }
+
     shadowTreeRegistry.visit(surfaceId, [&](ShadowTree const &shadowTree) {
       shadowTree.commit(
           [&](RootShadowNode const &oldRootShadowNode)

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -18,6 +18,7 @@
 
 #ifdef __ANDROID__
 #include <fbjni/fbjni.h>
+#include <folly/json.h>
 #endif // __ANDROID__
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -790,7 +791,7 @@ bool ReanimatedModuleProxy::handleRawEvent(
   // (res == true), but for now handleEvent always returns false. Thankfully,
   // performOperations does not trigger a lot of code if there is nothing to
   // be done so this is fine for now.
-  performOperations(true);
+  performOperations(true, true);
   return res;
 }
 
@@ -817,8 +818,9 @@ void ReanimatedModuleProxy::updateProps(
   }
 }
 
-void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
+void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, const bool mountSync = true) {
   ReanimatedSystraceSection s("performOperations");
+//  LOG(INFO) << "[HANNODEBUG] [reanimated] ------------ performOperations called";
 
   if (!layoutAnimationFlushRequests_.empty() && !isTriggeredByEvent) {
     auto flushRequestsCopy = std::move(layoutAnimationFlushRequests_);
@@ -832,6 +834,7 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
 
   if (operationsInBatch_.empty() && tagsToRemove_.empty()) {
     // nothing to do
+//    LOG(INFO) << "[HANNODEBUG] [reanimated] no op to perform";
     return;
   }
 
@@ -895,6 +898,7 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
     // In this case, we should skip the commit here and let React Native do
     // it. The commit will include the current values from PropsRegistry which
     // will be applied in ReanimatedCommitHook.
+//    LOG(INFO) << "[HANNODEBUG] [reanimated] shouldReanimatedSkipCommit()";
     return;
   }
 
@@ -910,15 +914,24 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
     if (layoutUpdatesByTag.contains(shadowNode->getTag())) {
       // Only push updates for updates that affect layout. Other updates
       // were already handled by updateNoneLayoutProps above
+      LOG(INFO)
+          << "[HANNODEBUG] Scheduling props update for "
+          << shadowNode->getComponentName() << "(" << shadowNode->getTag() << ")" << " props: " << folly::toJson(dynamicFromValue(rt, *props));
       propsMapBySurface[surfaceId][family].emplace_back(rt, std::move(*props));
     }
   }
 
   for (auto const &[surfaceId, propsMap] : propsMapBySurface) {
-    if (propsMapBySurface.size() == 0) {
+    auto size = propsMapBySurface.size();
+    if (size == 0) {
         // Avoid calling commit(sync = true), as that could force React Native to sync flush all pending mount transactions
+//        LOG(INFO) << "[HANNODEBUG] [reanimated] no update, continue";
       continue;
     }
+
+    LOG(INFO)
+        << "[HANNODEBUG] Committing updated props to ShadowTree with " << propsMap.size()
+        << " families to update.";
 
     shadowTreeRegistry.visit(surfaceId, [&](ShadowTree const &shadowTree) {
       shadowTree.commit(
@@ -943,7 +956,7 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent) {
           },
           {/* .enableStateReconciliation = */
            false,
-           /* .mountSynchronously = */ true});
+           /* .mountSynchronously = */ mountSync});
     });
   }
 }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -820,7 +820,6 @@ void ReanimatedModuleProxy::updateProps(
 
 void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, const bool mountSync = true) {
   ReanimatedSystraceSection s("performOperations");
-//  LOG(INFO) << "[HANNODEBUG] [reanimated] ------------ performOperations called";
 
   if (!layoutAnimationFlushRequests_.empty() && !isTriggeredByEvent) {
     auto flushRequestsCopy = std::move(layoutAnimationFlushRequests_);
@@ -834,7 +833,6 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
 
   if (operationsInBatch_.empty() && tagsToRemove_.empty()) {
     // nothing to do
-//    LOG(INFO) << "[HANNODEBUG] [reanimated] no op to perform";
     return;
   }
 
@@ -898,7 +896,6 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
     // In this case, we should skip the commit here and let React Native do
     // it. The commit will include the current values from PropsRegistry which
     // will be applied in ReanimatedCommitHook.
-//    LOG(INFO) << "[HANNODEBUG] [reanimated] shouldReanimatedSkipCommit()";
     return;
   }
 
@@ -914,9 +911,6 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
     if (layoutUpdatesByTag.contains(shadowNode->getTag())) {
       // Only push updates for updates that affect layout. Other updates
       // were already handled by updateNoneLayoutProps above
-      LOG(INFO)
-          << "[HANNODEBUG] Scheduling props update for "
-          << shadowNode->getComponentName() << "(" << shadowNode->getTag() << ")" << " props: " << folly::toJson(dynamicFromValue(rt, *props));
       propsMapBySurface[surfaceId][family].emplace_back(rt, std::move(*props));
     }
   }
@@ -925,13 +919,8 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
     auto size = propsMapBySurface.size();
     if (size == 0) {
         // Avoid calling commit(sync = true), as that could force React Native to sync flush all pending mount transactions
-//        LOG(INFO) << "[HANNODEBUG] [reanimated] no update, continue";
       continue;
     }
-
-    LOG(INFO)
-        << "[HANNODEBUG] Committing updated props to ShadowTree with " << propsMap.size()
-        << " families to update.";
 
     shadowTreeRegistry.visit(surfaceId, [&](ShadowTree const &shadowTree) {
       shadowTree.commit(
@@ -956,6 +945,13 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
           },
           {/* .enableStateReconciliation = */
            false,
+            // mountSync=true: default case, immediately flush our updates to the native layer
+            // mountSycn=false: performOperations() was called due to an intercepted event.
+            // This event (e.g. scroll event) got dispatched during a drawing phase:
+            // e.g. see here: https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/view/View.java;l=24107;drc=dc12cf3a98ae51c83fa0c5edae5cc0a72d84f4e7
+            // In that case performOperations() might try to synchronously update the UI, which
+            // could cause view removal, which could crash the drawing phase.
+            // Thats why in those cases we want to avoid synchronous mounting.
            /* .mountSynchronously = */ mountSync});
     });
   }

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -124,7 +124,7 @@ class ReanimatedModuleProxy
 
   void removeFromPropsRegistry(jsi::Runtime &rt, const jsi::Value &viewTags);
 
-  void performOperations(const bool isTriggeredByEvent);
+  void performOperations(const bool isTriggeredByEvent, const bool mountSync);
 
   void markNodeAsRemovable(
       jsi::Runtime &rt,

--- a/packages/react-native-reanimated/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -74,7 +74,7 @@ public class NativeProxy extends NativeProxyCommon {
 
   public native boolean isAnyHandlerWaitingForEvent(String eventName, int emitterReactTag);
 
-  public native void performOperations(boolean isTriggeredByEvent);
+  public native void performOperations(boolean isTriggeredByEvent, boolean mountSync);
 
   /** Modifies tags in place, setting not mounted view tags to -1 at their index. */
   @DoNotStrip

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -170,9 +170,9 @@ bool NativeProxy::isAnyHandlerWaitingForEvent(
       eventName, emitterReactTag);
 }
 
-void NativeProxy::performOperations(const bool isTriggeredByEvent) {
+void NativeProxy::performOperations(const bool isTriggeredByEvent, const bool mountSync) {
 #ifdef RCT_NEW_ARCH_ENABLED
-  reanimatedModuleProxy_->performOperations(isTriggeredByEvent);
+  reanimatedModuleProxy_->performOperations(isTriggeredByEvent, mountSync);
 #endif
 }
 

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -195,7 +195,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   bool isAnyHandlerWaitingForEvent(
       const std::string &eventName,
       const int emitterReactTag);
-  void performOperations(const bool isTriggeredByEvent);
+  void performOperations(const bool isTriggeredByEvent, const bool mountSync);
   bool getIsReducedMotion();
   void requestRender(std::function<void(double)> onRender);
   void registerEventHandler();

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -3,8 +3,16 @@ package com.swmansion.reanimated;
 import static java.lang.Float.NaN;
 
 import android.graphics.drawable.Drawable;
+import android.os.Looper;
 import android.os.SystemClock;
+import android.os.Trace;
+import android.view.Choreographer;
 import android.view.View;
+import android.view.ViewParent;
+import android.view.ViewTreeObserver;
+import android.view.animation.AnimationUtils;
+
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.JavaOnlyMap;
@@ -24,6 +32,8 @@ import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactShadowNode;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
+import com.facebook.react.uimanager.RootView;
+import com.facebook.react.uimanager.RootViewUtil;
 import com.facebook.react.uimanager.UIImplementation;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -169,6 +179,8 @@ public class NodesManager implements EventDispatcherListener {
 
   private Queue<NativeUpdateOperation> mOperationsInBatch = new LinkedList<>();
   private boolean mTryRunBatchUpdatesSynchronously = false;
+  int count = 0;
+
 
   public NodesManager(ReactContext context, WorkletsModule workletsModule) {
     mContext = context;
@@ -192,6 +204,51 @@ public class NodesManager implements EventDispatcherListener {
             onAnimationFrame(frameTimeNanos);
           }
         };
+
+//      Choreographer.FrameCallback callback = new Choreographer.FrameCallback() {
+//            @Override
+//            public void doFrame(long time) {
+//                android.util.Log.d("HannoDebug", "[Reanimated] [" + count + "] frame animation callback: " + time);
+//                Choreographer.getInstance().postFrameCallback(this);
+//            }
+//      };
+//    Choreographer.getInstance().postFrameCallback(callback); // KICK DRUM
+    // get current looper:
+
+//    android.util.Log.d("HannoDebug", "[Reanimated] Initializing NodesManager, has activity yet: " + (context.getCurrentActivity() != null));
+//    View decorView = context.getCurrentActivity().getWindow().getDecorView();
+//    decorView.getViewTreeObserver().addOnDrawListener(() -> {
+//        int myId = count++;
+//
+//        android.util.Log.d("HannoDebug", "[Reanimated] ["+myId+"] onDraw called");
+//        double start = System.nanoTime() / 1_000_000.0;
+//        // weak?
+//        decorView.post(() -> {
+//            double end = System.nanoTime() / 1_000_000.0;
+//            android.util.Log.d("HannoDebug", "[Reanimated] ["+myId+"] onDraw finished, took ms: " + (end - start));
+//        });
+//    });
+//      Choreographer.getInstance().
+
+
+
+    // TODO: this should run on the UI thread, after we know the Root view / surface has been created?
+//        try {
+//            @Nullable View rootView = mUIManager.resolveView(0);
+//            if (rootView != null) {
+//                android.util.Log.d("HannoDebug", "[Reanimated] Found root view when trying to initialize NodesManager: " + rootView);
+//                RootView rootView2 = RootViewUtil.getRootView(rootView);
+//                if (rootView2 != null) {
+//                    android.util.Log.d("HannoDebug", "[Reanimated] Initializing NodesManager with root view: " + rootView2);
+//                } else {
+//                    android.util.Log.d("HannoDebug", "[Reanimated] Root view 2 is null when trying to initialize NodesManager");
+//                }
+//            } else {
+//                android.util.Log.d("HannoDebug", "[Reanimated] Root view is null when trying to initialize NodesManager");
+//            }
+//        } catch (IllegalViewOperationException ex) {
+//            android.util.Log.d("HannoDebug", "[Reanimated] Caught exception when trying to initialize NodesManager: " + ex.getMessage());
+//        }
 
     if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // We register as event listener at the end, because we pass `this` and we haven't finished
@@ -242,12 +299,27 @@ public class NodesManager implements EventDispatcherListener {
     }
   }
 
-  public void performOperations(boolean isTriggeredByEvent) {
+  @androidx.annotation.UiThread
+  public void performOperations(boolean isTriggeredByEvent, boolean isDrawing) {
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       if (mNativeProxy != null) {
-        isPerformOperationsActive = true;
-        mNativeProxy.performOperations(isTriggeredByEvent);
-        isPerformOperationsActive = false;
+        if (!isDrawing) {
+            // Default case
+            isPerformOperationsActive = true;
+            mNativeProxy.performOperations(isTriggeredByEvent);
+            isPerformOperationsActive = false;
+        } else {
+            // Very special case: performOperations() was called due to an intercepted event.
+            // This event got dispatched during a drawing phase (e.g. scroll event):
+            // e.g. see here: https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/view/View.java;l=24107;drc=dc12cf3a98ae51c83fa0c5edae5cc0a72d84f4e7
+            // In that case performOperations() might try to synchronously update the UI, which
+            // could cause view removal, which could crash the drawing phase
+            mContext.runOnUiQueueThread(() -> {
+                isPerformOperationsActive = true;
+                mNativeProxy.performOperations(isTriggeredByEvent);
+                isPerformOperationsActive = false;
+            });
+        }
       }
     } else if (!mOperationsInBatch.isEmpty()) {
       final Queue<NativeUpdateOperation> copiedOperationsQueue = mOperationsInBatch;
@@ -320,7 +392,7 @@ public class NodesManager implements EventDispatcherListener {
         }
       }
 
-      performOperations(false);
+      performOperations(false, false);
     }
 
     mCallbackPosted.set(false);
@@ -387,7 +459,7 @@ public class NodesManager implements EventDispatcherListener {
        */
       String eventName = event.getEventName();
       if (eventName.contains("GestureHandler") || eventName.contains("Scroll")) {
-        performOperations(true);
+        performOperations(true, event.isDrawing());
         // Note(@hannojg): there has been a new edit in
         // https://github.com/software-mansion/react-native-reanimated/pull/8459
         // This will prevent to run scheduled layout animation synchronously here when triggered by

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -3,7 +3,9 @@ package com.swmansion.reanimated;
 import static java.lang.Float.NaN;
 
 import android.graphics.drawable.Drawable;
+import android.os.Handler;
 import android.os.Looper;
+import android.os.Message;
 import android.os.SystemClock;
 import android.os.Trace;
 import android.view.Choreographer;
@@ -299,6 +301,10 @@ public class NodesManager implements EventDispatcherListener {
     }
   }
 
+  int scheduled = 0;
+  Handler mainHandler = new Handler(Looper.getMainLooper());
+  boolean isScheduled = false;
+
   @androidx.annotation.UiThread
   public void performOperations(boolean isTriggeredByEvent, boolean isDrawing) {
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
@@ -310,15 +316,30 @@ public class NodesManager implements EventDispatcherListener {
             isPerformOperationsActive = false;
         } else {
             // Very special case: performOperations() was called due to an intercepted event.
-            // This event got dispatched during a drawing phase (e.g. scroll event):
+            // This event (e.g. scroll event) got dispatched during a drawing phase:
             // e.g. see here: https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/view/View.java;l=24107;drc=dc12cf3a98ae51c83fa0c5edae5cc0a72d84f4e7
             // In that case performOperations() might try to synchronously update the UI, which
-            // could cause view removal, which could crash the drawing phase
-            mContext.runOnUiQueueThread(() -> {
+            // could cause view removal, which could crash the drawing phase.
+            int currentScheduled = scheduled++;
+
+            if (isScheduled) {
+//                FLog.w("HannODebug",
+//                    "["+currentScheduled+"] performOperations() already scheduled, skipping.");
+                return;
+            }
+
+//            FLog.w("HannODebug",
+//                "["+currentScheduled+"] Scheduling performOperations() asynchronously due to drawing phase.");
+
+            mainHandler.postAtFrontOfQueue(() -> {
+                isScheduled = false;
+//                FLog.w("HannODebug",
+//                    "["+currentScheduled+"] Running scheduled performOperations() now.");
                 isPerformOperationsActive = true;
                 mNativeProxy.performOperations(isTriggeredByEvent);
                 isPerformOperationsActive = false;
             });
+            isScheduled = true;
         }
       }
     } else if (!mOperationsInBatch.isEmpty()) {

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java
@@ -207,51 +207,6 @@ public class NodesManager implements EventDispatcherListener {
           }
         };
 
-//      Choreographer.FrameCallback callback = new Choreographer.FrameCallback() {
-//            @Override
-//            public void doFrame(long time) {
-//                android.util.Log.d("HannoDebug", "[Reanimated] [" + count + "] frame animation callback: " + time);
-//                Choreographer.getInstance().postFrameCallback(this);
-//            }
-//      };
-//    Choreographer.getInstance().postFrameCallback(callback); // KICK DRUM
-    // get current looper:
-
-//    android.util.Log.d("HannoDebug", "[Reanimated] Initializing NodesManager, has activity yet: " + (context.getCurrentActivity() != null));
-//    View decorView = context.getCurrentActivity().getWindow().getDecorView();
-//    decorView.getViewTreeObserver().addOnDrawListener(() -> {
-//        int myId = count++;
-//
-//        android.util.Log.d("HannoDebug", "[Reanimated] ["+myId+"] onDraw called");
-//        double start = System.nanoTime() / 1_000_000.0;
-//        // weak?
-//        decorView.post(() -> {
-//            double end = System.nanoTime() / 1_000_000.0;
-//            android.util.Log.d("HannoDebug", "[Reanimated] ["+myId+"] onDraw finished, took ms: " + (end - start));
-//        });
-//    });
-//      Choreographer.getInstance().
-
-
-
-    // TODO: this should run on the UI thread, after we know the Root view / surface has been created?
-//        try {
-//            @Nullable View rootView = mUIManager.resolveView(0);
-//            if (rootView != null) {
-//                android.util.Log.d("HannoDebug", "[Reanimated] Found root view when trying to initialize NodesManager: " + rootView);
-//                RootView rootView2 = RootViewUtil.getRootView(rootView);
-//                if (rootView2 != null) {
-//                    android.util.Log.d("HannoDebug", "[Reanimated] Initializing NodesManager with root view: " + rootView2);
-//                } else {
-//                    android.util.Log.d("HannoDebug", "[Reanimated] Root view 2 is null when trying to initialize NodesManager");
-//                }
-//            } else {
-//                android.util.Log.d("HannoDebug", "[Reanimated] Root view is null when trying to initialize NodesManager");
-//            }
-//        } catch (IllegalViewOperationException ex) {
-//            android.util.Log.d("HannoDebug", "[Reanimated] Caught exception when trying to initialize NodesManager: " + ex.getMessage());
-//        }
-
     if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // We register as event listener at the end, because we pass `this` and we haven't finished
       // constructing an object yet.
@@ -303,44 +258,14 @@ public class NodesManager implements EventDispatcherListener {
 
   int scheduled = 0;
   Handler mainHandler = new Handler(Looper.getMainLooper());
-  boolean isScheduled = false;
 
   @androidx.annotation.UiThread
   public void performOperations(boolean isTriggeredByEvent, boolean isDrawing) {
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       if (mNativeProxy != null) {
-        if (!isDrawing) {
-            // Default case
-            isPerformOperationsActive = true;
-            mNativeProxy.performOperations(isTriggeredByEvent);
-            isPerformOperationsActive = false;
-        } else {
-            // Very special case: performOperations() was called due to an intercepted event.
-            // This event (e.g. scroll event) got dispatched during a drawing phase:
-            // e.g. see here: https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/view/View.java;l=24107;drc=dc12cf3a98ae51c83fa0c5edae5cc0a72d84f4e7
-            // In that case performOperations() might try to synchronously update the UI, which
-            // could cause view removal, which could crash the drawing phase.
-            int currentScheduled = scheduled++;
-
-            if (isScheduled) {
-//                FLog.w("HannODebug",
-//                    "["+currentScheduled+"] performOperations() already scheduled, skipping.");
-                return;
-            }
-
-//            FLog.w("HannODebug",
-//                "["+currentScheduled+"] Scheduling performOperations() asynchronously due to drawing phase.");
-
-            mainHandler.postAtFrontOfQueue(() -> {
-                isScheduled = false;
-//                FLog.w("HannODebug",
-//                    "["+currentScheduled+"] Running scheduled performOperations() now.");
-                isPerformOperationsActive = true;
-                mNativeProxy.performOperations(isTriggeredByEvent);
-                isPerformOperationsActive = false;
-            });
-            isScheduled = true;
-        }
+          isPerformOperationsActive = true;
+          mNativeProxy.performOperations(isTriggeredByEvent, /* mountSync */ !isDrawing);
+          isPerformOperationsActive = false;
       }
     } else if (!mOperationsInBatch.isEmpty()) {
       final Queue<NativeUpdateOperation> copiedOperationsQueue = mOperationsInBatch;

--- a/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
+++ b/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java
@@ -249,7 +249,7 @@ public abstract class NativeProxyCommon {
   @DoNotStrip
   void maybeFlushUIUpdatesQueue() {
     if (!mNodesManager.isAnimationRunning()) {
-      mNodesManager.performOperations(false);
+      mNodesManager.performOperations(false, false);
     }
   }
 }


### PR DESCRIPTION
Depends on the ability to mark events as `isDrawing`:

- https://github.com/discord/react-native/pull/128

When an event is marked as such we will not sync commit to the shadow tree to prevent the possibility of view hierarchy alternating mount transactions happening.
We will however execute all none layout related animations right away with `syncUpdatePropsOnUI`, which should work well for most cases (ie. changing a translate value on scroll)