### PR TITLE
fix(android): preserveMountedTags bail on JS thread call

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/LayoutAnimations/LayoutAnimationsProxy.cpp
@@ -424,6 +424,10 @@ void LayoutAnimationsProxy::addOngoingAnimations(
   }
 
   auto correctedTags = preserveMountedTags_(tagsToUpdate);
+  if (!correctedTags.has_value()) {
+      // this is nullopt if this is being called from the JS thread.
+      return;
+  }
 
   // since the map is not updated, we can assume that the ordering of tags in
   // correctedTags matches the iterator

--- a/packages/react-native-reanimated/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/packages/react-native-reanimated/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -4,6 +4,7 @@ import androidx.annotation.OptIn;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
@@ -78,11 +79,18 @@ public class NativeProxy extends NativeProxyCommon {
 
   /** Modifies tags in place, setting not mounted view tags to -1 at their index. */
   @DoNotStrip
-  public void preserveMountedTags(int[] tags) {
+  public boolean preserveMountedTags(int[] tags) {
+    if (!UiThreadUtil.isOnUiThread()) {
+        // We want to avoid executing LayoutAnimationProxy::addOngoingAnimation
+        // from the JS thread to avoid the occurrence of this bug:
+        // https://github.com/software-mansion/react-native-reanimated/issues/7493#issuecomment-3728435106
+        return false;
+    }
+
     for (int i = 0; i < tags.length; i++) {
+      try {
       // Note: resolveView has assertOnUiThread, which only logs as softexception in debug
       // It is actually completely thread safe and there is a RFC in RN to do something about it
-      try {
         if (mFabricUIManager.resolveView(tags[i]) == null) {
           tags[i] = -1;
         }
@@ -90,6 +98,8 @@ public class NativeProxy extends NativeProxyCommon {
         tags[i] = -1;
       }
     }
+
+    return true;
   }
 
   @Override

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.cpp
@@ -237,15 +237,17 @@ void NativeProxy::synchronouslyUpdateUIProps(
     method(javaPart_.get(), tag, uiProps);
 }
 
-std::unique_ptr<int[]> NativeProxy::preserveMountedTags(
+std::optional<std::unique_ptr<int[]>> NativeProxy::preserveMountedTags(
     std::vector<int> &tags) {
   static const auto method =
-      getJniMethod<void(jni::alias_ref<jni::JArrayInt>)>(
+      getJniMethod<jboolean(jni::alias_ref<jni::JArrayInt>)>(
           "preserveMountedTags");
   auto jArrayInt = jni::JArrayInt::newArray(tags.size());
   jArrayInt->setRegion(0, tags.size(), tags.data());
 
-  method(javaPart_.get(), jArrayInt);
+  if (!method(javaPart_.get(), jArrayInt)) {
+      return {};
+  }
 
   auto region = jArrayInt->getRegion(0, tags.size());
   return region;

--- a/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
+++ b/packages/react-native-reanimated/android/src/main/cpp/reanimated/android/NativeProxy.h
@@ -185,7 +185,7 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   void installJSIBindings();
 #ifdef RCT_NEW_ARCH_ENABLED
   void synchronouslyUpdateUIProps(Tag viewTag, const folly::dynamic &props);
-  std::unique_ptr<int[]> preserveMountedTags(
+  std::optional<std::unique_ptr<int[]>> preserveMountedTags(
       std::vector<int> &tags);
 #endif // RCT_NEW_ARCH_ENABLED
   PlatformDepMethodsHolder getPlatformDependentMethods();


### PR DESCRIPTION
Enable bailing in `LayoutAnimationsProxy::addOngoingAnimations` when called from JS thread, as this helps to prevent RetryableMountingLayer exceptions