### PR TITLE
fix animated colors bug

### DIFF
--- a/packages/react-native-reanimated/src/common/style/processors/colors.ts
+++ b/packages/react-native-reanimated/src/common/style/processors/colors.ts
@@ -97,7 +97,7 @@ export function processColorNumber(value: unknown): number | null {
 }
 
 function unprocessColorNumber(value: number): string {
-  const a = value >>> 24;
+  const a = (value >>> 24) / 255;
   const r = (value << 8) >>> 24;
   const g = (value << 16) >>> 24;
   const b = (value << 24) >>> 24;

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -367,7 +367,7 @@ export function createAnimatedComponent(
     }
 
     _syncStylePropsBackToReact(props: StyleProps) {
-      this.setState({ reanimatedProps: props });
+      this.setState({ settledProps: props });
     }
 
     getComponentViewTag() {
@@ -815,7 +815,7 @@ export function createAnimatedComponent(
         const flatStyles = StyleSheet.flatten(filteredProps.style as object);
         const mergedStyles = {
           ...flatStyles,
-          ...this.state.reanimatedProps,
+          ...this.state.settledProps,
         };
 
         return (
@@ -823,9 +823,9 @@ export function createAnimatedComponent(
             nativeID={nativeID}
             {...filteredProps}
             {...jestProps}
-            {...this.state.reanimatedProps}
-            {...this.state.settledProps}
             style={mergedStyles}
+            {...this.state.settledProps}
+            {...this.state.reanimatedProps}
             // Casting is used here, because ref can be null - in that case it cannot be assigned to HTMLElement.
             // After spending some time trying to figure out what to do with this problem, we decided to leave it this way
             ref={this._setComponentRef as (ref: Component) => void}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
In [this PR](https://github.com/discord/react-native-reanimated/pull/28) I accidentally broke the animated colors handling, this PR fixes it and additionally adds one more fix to the logic added in the former PR(taken from this [PR](https://github.com/software-mansion/react-native-reanimated/pull/8841)).

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

## Test plan

<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
