### PR TITLE
cherry-pick of ios-synchronously-update-props

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -704,7 +704,6 @@ void ReanimatedModuleProxy::unmarkNodeAsRemovable(
     jsi::Runtime &rt,
     const jsi::Object &props,
     Tag tag) {
-
     jsi::Object nonLayoutPropsJSI(rt);
     bool hasNonLayoutProps = false;
     bool hasLayoutProps = false;
@@ -727,9 +726,16 @@ void ReanimatedModuleProxy::unmarkNodeAsRemovable(
         }
     }
 
+    // Mirror upstream behavior: on iOS fast path, run synchronous updates only
+    // when the whole update can stay off the ShadowTree commit path.
+#if __APPLE__
+    // On iOS, synchronous updates are routed in performOperations after
+    // classifying the whole operation payload.
+#else
     if (hasNonLayoutProps) {
         synchronouslyUpdateUIPropsFunction_(rt, tag, nonLayoutPropsJSI);
     }
+#endif
 
     return hasLayoutProps;
 }
@@ -870,6 +876,69 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
 
   jsi::Runtime &rt = uiWorkletRuntime_->getJSIRuntime();
 
+#if __APPLE__
+  static const std::unordered_set<std::string> synchronousProps = {
+      "opacity",
+      "elevation",
+      "zIndex",
+      "shadowOpacity",
+      "shadowRadius",
+      "backgroundColor",
+      // "color", // TODO: fix animating color of Animated.Text
+      "tintColor",
+      "borderRadius",
+      "borderTopLeftRadius",
+      "borderTopRightRadius",
+      "borderTopStartRadius",
+      "borderTopEndRadius",
+      "borderBottomLeftRadius",
+      "borderBottomRightRadius",
+      "borderBottomStartRadius",
+      "borderBottomEndRadius",
+      "borderStartStartRadius",
+      "borderStartEndRadius",
+      "borderEndStartRadius",
+      "borderEndEndRadius",
+      "borderColor",
+      "borderTopColor",
+      "borderBottomColor",
+      "borderLeftColor",
+      "borderRightColor",
+      "borderStartColor",
+      "borderEndColor",
+      "transform",
+  };
+
+  decltype(copiedOperationsQueue) shadowTreeOperationsQueue;
+  std::unordered_set<Tag> forceShadowTreeUpdatesByTag;
+  shadowTreeOperationsQueue.reserve(copiedOperationsQueue.size());
+  forceShadowTreeUpdatesByTag.reserve(copiedOperationsQueue.size());
+  for (auto &operation : copiedOperationsQueue) {
+    const auto &shadowNode = operation.first;
+    auto &propsValue = operation.second;
+    const auto propsObject = propsValue->asObject(rt);
+    const auto propNames = propsObject.getPropertyNames(rt);
+    bool hasOnlySynchronousProps = propNames.size(rt) > 0;
+
+    for (size_t i = 0; i < propNames.size(rt); i++) {
+      const auto propName = propNames.getValueAtIndex(rt, i).asString(rt).utf8(rt);
+      const bool isLayoutProp = collection::contains(nativePropNames_, propName);
+      if (isLayoutProp || !synchronousProps.contains(propName)) {
+        hasOnlySynchronousProps = false;
+        break;
+      }
+    }
+
+    if (hasOnlySynchronousProps) {
+      synchronouslyUpdateUIPropsFunction_(rt, shadowNode->getTag(), propsObject);
+    } else {
+      forceShadowTreeUpdatesByTag.insert(shadowNode->getTag());
+      shadowTreeOperationsQueue.emplace_back(shadowNode, std::move(propsValue));
+    }
+  }
+  copiedOperationsQueue = std::move(shadowTreeOperationsQueue);
+#endif // __APPLE__
+
   std::unordered_set<Tag> layoutUpdatesByTag;
   {
     auto lock = propsRegistry_->createLock();
@@ -900,6 +969,11 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
         
         // Pass the JSI object directly
         bool hasLayoutUpdates = updateNoneLayoutProps(rt, props->asObject(rt), tag);
+#if __APPLE__
+        if (forceShadowTreeUpdatesByTag.contains(tag)) {
+            hasLayoutUpdates = true;
+        }
+#endif
         if (hasLayoutUpdates) {
             layoutUpdatesByTag.insert(tag);
         }

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -439,6 +439,24 @@ using namespace facebook::react;
   // so that's why we need to call `finalizeUpdates` here.
   [componentView finalizeUpdates:RNComponentViewUpdateMask{}];
 }
+
+- (void)synchronouslyUpdateUIProps:(const int)viewTag props:(const folly::dynamic &)props
+{
+  RCTAssertMainQueue();
+
+  RCTSurfacePresenter *surfacePresenter = _bridge.surfacePresenter ?: _surfacePresenter;
+  RCTComponentViewRegistry *componentViewRegistry = surfacePresenter.mountingManager.componentViewRegistry;
+  REAUIView<RCTComponentViewProtocol> *componentView =
+      [componentViewRegistry findComponentViewWithTag:viewTag];
+
+  NSSet<NSString *> *propKeysManagedByAnimated = [componentView propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN];
+  [surfacePresenter schedulerDidSynchronouslyUpdateViewOnUIThread:viewTag props:props];
+  [componentView setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:propKeysManagedByAnimated];
+
+  // `schedulerDidSynchronouslyUpdateViewOnUIThread` does not flush some props (e.g. backgroundColor),
+  // so finalize updates explicitly.
+  [componentView finalizeUpdates:RNComponentViewUpdateMask{}];
+}
 #else
 
 - (void)updateProps:(nonnull NSDictionary *)props

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -24,6 +24,8 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTScheduler.h>
 #import <React/RCTSurfacePresenter.h>
+#include <jsi/JSIDynamic.h>
+#include <folly/dynamic.h>
 #import <react/renderer/core/ShadowNode.h>
 #import <react/renderer/uimanager/primitives.h>
 #endif
@@ -39,6 +41,12 @@
                          commandID:(id /*(NSString or NSNumber) */)commandID
                        commandArgs:(NSArray<id> *)commandArgs;
 @end
+
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface REANodesManager (SynchronousUIProps)
+- (void)synchronouslyUpdateUIProps:(const int)viewTag props:(const folly::dynamic &)props;
+@end
+#endif
 
 namespace reanimated {
 
@@ -105,9 +113,8 @@ RequestRenderFunction makeRequestRender(REANodesManager *nodesManager)
 SynchronouslyUpdateUIPropsFunction makeSynchronouslyUpdateUIPropsFunction(REANodesManager *nodesManager)
 {
   auto synchronouslyUpdateUIPropsFunction = [nodesManager](jsi::Runtime &rt, Tag tag, const jsi::Object &props) -> void {
-    NSNumber *viewTag = @(tag);
-    NSDictionary *uiProps = convertJSIObjectToNSDictionary(rt, props);
-    [nodesManager synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
+    auto dynamicProps = jsi::dynamicFromValue(rt, jsi::Value(rt, props));
+    [nodesManager synchronouslyUpdateUIProps:tag props:dynamicProps];
   };
   return synchronouslyUpdateUIPropsFunction;
 }

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -24,8 +24,6 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTScheduler.h>
 #import <React/RCTSurfacePresenter.h>
-#include <jsi/JSIDynamic.h>
-#include <folly/dynamic.h>
 #import <react/renderer/core/ShadowNode.h>
 #import <react/renderer/uimanager/primitives.h>
 #endif


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary
This PR ports the iOS synchronous UI-props fast path (inspired by upstream `synchronouslyUpdateViewOnUIThread`) and adapts it to the current Discord branch architecture.

What was added:
- an iOS synchronous props update path in `REANodesManager` using `schedulerDidSynchronouslyUpdateViewOnUIThread`,
- wiring in `PlatformDepMethodsHolderImpl` with conversion from
`jsi::Object` to `folly::dynamic`,
- routing logic in `ReanimatedModuleProxy` to:
  - separate updates eligible for sync path (whitelisted non-layout props),
  - keep all other updates on the `ShadowTree` commit path,
  - force mixed/non-eligible batches to remain on commit path to avoid incorrect sync+commit mixing for the same update.

Goal: increase fast-path usage on iOS and reduce `ShadowTree` commit cost for animated non-layout props.

old arch:
<video src="https://github.com/user-attachments/assets/5495f4bf-6e22-454c-a963-61e72e399339" /> 

new arch before: 
<video src="https://github.com/user-attachments/assets/0243dd98-4d70-425c-bae6-c25b436c18b8" />

new arch after : 
<video src="https://github.com/user-attachments/assets/ce2bbd97-5562-4310-845d-4321eca27599" />

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->


<!-- Provide a minimal but complete code snippet that can be used to test out this change along with instructions how to run it and a description of the expected behavior. -->
