### PR TITLE
Revert "cherry-pick of ios-synchronously-update-props"

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -704,6 +704,7 @@ void ReanimatedModuleProxy::unmarkNodeAsRemovable(
     jsi::Runtime &rt,
     const jsi::Object &props,
     Tag tag) {
+
     jsi::Object nonLayoutPropsJSI(rt);
     bool hasNonLayoutProps = false;
     bool hasLayoutProps = false;
@@ -726,16 +727,9 @@ void ReanimatedModuleProxy::unmarkNodeAsRemovable(
         }
     }
 
-    // Mirror upstream behavior: on iOS fast path, run synchronous updates only
-    // when the whole update can stay off the ShadowTree commit path.
-#if __APPLE__
-    // On iOS, synchronous updates are routed in performOperations after
-    // classifying the whole operation payload.
-#else
     if (hasNonLayoutProps) {
         synchronouslyUpdateUIPropsFunction_(rt, tag, nonLayoutPropsJSI);
     }
-#endif
 
     return hasLayoutProps;
 }
@@ -876,69 +870,6 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
 
   jsi::Runtime &rt = uiWorkletRuntime_->getJSIRuntime();
 
-#if __APPLE__
-  static const std::unordered_set<std::string> synchronousProps = {
-      "opacity",
-      "elevation",
-      "zIndex",
-      "shadowOpacity",
-      "shadowRadius",
-      "backgroundColor",
-      // "color", // TODO: fix animating color of Animated.Text
-      "tintColor",
-      "borderRadius",
-      "borderTopLeftRadius",
-      "borderTopRightRadius",
-      "borderTopStartRadius",
-      "borderTopEndRadius",
-      "borderBottomLeftRadius",
-      "borderBottomRightRadius",
-      "borderBottomStartRadius",
-      "borderBottomEndRadius",
-      "borderStartStartRadius",
-      "borderStartEndRadius",
-      "borderEndStartRadius",
-      "borderEndEndRadius",
-      "borderColor",
-      "borderTopColor",
-      "borderBottomColor",
-      "borderLeftColor",
-      "borderRightColor",
-      "borderStartColor",
-      "borderEndColor",
-      "transform",
-  };
-
-  decltype(copiedOperationsQueue) shadowTreeOperationsQueue;
-  std::unordered_set<Tag> forceShadowTreeUpdatesByTag;
-  shadowTreeOperationsQueue.reserve(copiedOperationsQueue.size());
-  forceShadowTreeUpdatesByTag.reserve(copiedOperationsQueue.size());
-  for (auto &operation : copiedOperationsQueue) {
-    const auto &shadowNode = operation.first;
-    auto &propsValue = operation.second;
-    const auto propsObject = propsValue->asObject(rt);
-    const auto propNames = propsObject.getPropertyNames(rt);
-    bool hasOnlySynchronousProps = propNames.size(rt) > 0;
-
-    for (size_t i = 0; i < propNames.size(rt); i++) {
-      const auto propName = propNames.getValueAtIndex(rt, i).asString(rt).utf8(rt);
-      const bool isLayoutProp = collection::contains(nativePropNames_, propName);
-      if (isLayoutProp || !synchronousProps.contains(propName)) {
-        hasOnlySynchronousProps = false;
-        break;
-      }
-    }
-
-    if (hasOnlySynchronousProps) {
-      synchronouslyUpdateUIPropsFunction_(rt, shadowNode->getTag(), propsObject);
-    } else {
-      forceShadowTreeUpdatesByTag.insert(shadowNode->getTag());
-      shadowTreeOperationsQueue.emplace_back(shadowNode, std::move(propsValue));
-    }
-  }
-  copiedOperationsQueue = std::move(shadowTreeOperationsQueue);
-#endif // __APPLE__
-
   std::unordered_set<Tag> layoutUpdatesByTag;
   {
     auto lock = propsRegistry_->createLock();
@@ -969,11 +900,6 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
         
         // Pass the JSI object directly
         bool hasLayoutUpdates = updateNoneLayoutProps(rt, props->asObject(rt), tag);
-#if __APPLE__
-        if (forceShadowTreeUpdatesByTag.contains(tag)) {
-            hasLayoutUpdates = true;
-        }
-#endif
         if (hasLayoutUpdates) {
             layoutUpdatesByTag.insert(tag);
         }

--- a/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/REANodesManager.mm
@@ -448,24 +448,6 @@ static BOOL _isPerformOperationsActive = NO;
   // so that's why we need to call `finalizeUpdates` here.
   [componentView finalizeUpdates:RNComponentViewUpdateMask{}];
 }
-
-- (void)synchronouslyUpdateUIProps:(const int)viewTag props:(const folly::dynamic &)props
-{
-  RCTAssertMainQueue();
-
-  RCTSurfacePresenter *surfacePresenter = _bridge.surfacePresenter ?: _surfacePresenter;
-  RCTComponentViewRegistry *componentViewRegistry = surfacePresenter.mountingManager.componentViewRegistry;
-  REAUIView<RCTComponentViewProtocol> *componentView =
-      [componentViewRegistry findComponentViewWithTag:viewTag];
-
-  NSSet<NSString *> *propKeysManagedByAnimated = [componentView propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN];
-  [surfacePresenter schedulerDidSynchronouslyUpdateViewOnUIThread:viewTag props:props];
-  [componentView setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:propKeysManagedByAnimated];
-
-  // `schedulerDidSynchronouslyUpdateViewOnUIThread` does not flush some props (e.g. backgroundColor),
-  // so finalize updates explicitly.
-  [componentView finalizeUpdates:RNComponentViewUpdateMask{}];
-}
 #else
 
 - (void)updateProps:(nonnull NSDictionary *)props

--- a/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
+++ b/packages/react-native-reanimated/apple/reanimated/apple/native/PlatformDepMethodsHolderImpl.mm
@@ -40,12 +40,6 @@
                        commandArgs:(NSArray<id> *)commandArgs;
 @end
 
-#ifdef RCT_NEW_ARCH_ENABLED
-@interface REANodesManager (SynchronousUIProps)
-- (void)synchronouslyUpdateUIProps:(const int)viewTag props:(const folly::dynamic &)props;
-@end
-#endif
-
 namespace reanimated {
 
 using namespace facebook;
@@ -111,8 +105,9 @@ RequestRenderFunction makeRequestRender(REANodesManager *nodesManager)
 SynchronouslyUpdateUIPropsFunction makeSynchronouslyUpdateUIPropsFunction(REANodesManager *nodesManager)
 {
   auto synchronouslyUpdateUIPropsFunction = [nodesManager](jsi::Runtime &rt, Tag tag, const jsi::Object &props) -> void {
-    auto dynamicProps = jsi::dynamicFromValue(rt, jsi::Value(rt, props));
-    [nodesManager synchronouslyUpdateUIProps:tag props:dynamicProps];
+    NSNumber *viewTag = @(tag);
+    NSDictionary *uiProps = convertJSIObjectToNSDictionary(rt, props);
+    [nodesManager synchronouslyUpdateViewOnUIThread:viewTag props:uiProps];
   };
   return synchronouslyUpdateUIPropsFunction;
 }


### PR DESCRIPTION
Reverts discord/react-native-reanimated#33

Will fix these app issues:
https://app.asana.com/1/236888843494340/project/1199705967702853/task/1213550009174768
https://app.asana.com/1/236888843494340/project/1199705967702853/task/1213550009174768
https://app.asana.com/1/236888843494340/project/1199705967702853/task/1213611766893133
https://app.asana.com/1/236888843494340/project/1199705967702853/task/1213561553032377

The iOS update props sync path was implemented for reanimated 4.x, our cherry pick for 3.19.4 had some edge cases that were not handled correctly. Even though they can be fixed to I think that it's safer to revert for now, since the performance gain from this synch update props is minimal in our app and there might be some edge cases that we are not aware of yet.