### PR TITLE
Wolewicki/update style on unfreeze

### DIFF
--- a/packages/react-native-reanimated/src/ViewDescriptorsSet.ts
+++ b/packages/react-native-reanimated/src/ViewDescriptorsSet.ts
@@ -1,37 +1,25 @@
 'use strict';
-import type { SharedValue } from './commonTypes';
+import type { SharedValue, StyleUpdaterContainer } from './commonTypes';
 import { makeMutable } from './core';
 import type { Descriptor } from './hook/commonTypes';
 
 export interface ViewDescriptorsSet {
   shareableViewDescriptors: SharedValue<Descriptor[]>;
-  add: (item: Descriptor) => void;
+  add: (item: Descriptor, updaterContainer?: StyleUpdaterContainer) => void;
   remove: (viewTag: number) => void;
   has: (viewTag: number) => boolean;
-  setForceUpdate: (fn: (() => void) | null) => void;
 }
 
 export function makeViewDescriptorsSet(): ViewDescriptorsSet {
   const shareableViewDescriptors = makeMutable<Descriptor[]>([]);
   const viewTags = new Set<number>();
-  // Tracks tags that were previously mounted then removed — these need forceUpdate on re-add.
-  const removedTags = new Set<number>();
-  // Plain closure variable — NOT stored on the data object to avoid being frozen by Reanimated.
-  let forceUpdateFn: (() => void) | null = null;
 
   const data: ViewDescriptorsSet = {
     shareableViewDescriptors,
 
-    setForceUpdate: (fn: (() => void) | null) => {
-      forceUpdateFn = fn;
-    },
-
-    add: (item: Descriptor) => {
-      const tag = item.tag as number;
-      const isReregistration = removedTags.has(tag);
-      removedTags.delete(tag);
-      viewTags.add(tag);
-      const forceUpdate = isReregistration ? forceUpdateFn : null;
+    add: (item: Descriptor, updaterContainer?: StyleUpdaterContainer) => {
+      viewTags.add(item.tag as number);
+      const updater = updaterContainer?.current;
       shareableViewDescriptors.modify((descriptors) => {
         'worklet';
         const index = descriptors.findIndex(
@@ -41,15 +29,14 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
           descriptors[index] = item;
         } else {
           descriptors.push(item);
-          forceUpdate?.();
         }
+        updater?.(true);
         return descriptors;
       }, false);
     },
 
     remove: (viewTag: number) => {
       viewTags.delete(viewTag);
-      removedTags.add(viewTag);
       shareableViewDescriptors.modify((descriptors) => {
         'worklet';
         const index = descriptors.findIndex(

--- a/packages/react-native-reanimated/src/ViewDescriptorsSet.ts
+++ b/packages/react-native-reanimated/src/ViewDescriptorsSet.ts
@@ -8,17 +8,30 @@ export interface ViewDescriptorsSet {
   add: (item: Descriptor) => void;
   remove: (viewTag: number) => void;
   has: (viewTag: number) => boolean;
+  setForceUpdate: (fn: (() => void) | null) => void;
 }
 
 export function makeViewDescriptorsSet(): ViewDescriptorsSet {
   const shareableViewDescriptors = makeMutable<Descriptor[]>([]);
   const viewTags = new Set<number>();
+  // Tracks tags that were previously mounted then removed — these need forceUpdate on re-add.
+  const removedTags = new Set<number>();
+  // Plain closure variable — NOT stored on the data object to avoid being frozen by Reanimated.
+  let forceUpdateFn: (() => void) | null = null;
 
   const data: ViewDescriptorsSet = {
     shareableViewDescriptors,
 
+    setForceUpdate: (fn: (() => void) | null) => {
+      forceUpdateFn = fn;
+    },
+
     add: (item: Descriptor) => {
-      viewTags.add(item.tag as number);
+      const tag = item.tag as number;
+      const isReregistration = removedTags.has(tag);
+      removedTags.delete(tag);
+      viewTags.add(tag);
+      const forceUpdate = isReregistration ? forceUpdateFn : null;
       shareableViewDescriptors.modify((descriptors) => {
         'worklet';
         const index = descriptors.findIndex(
@@ -28,6 +41,7 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
           descriptors[index] = item;
         } else {
           descriptors.push(item);
+          forceUpdate?.();
         }
         return descriptors;
       }, false);
@@ -35,6 +49,7 @@ export function makeViewDescriptorsSet(): ViewDescriptorsSet {
 
     remove: (viewTag: number) => {
       viewTags.delete(viewTag);
+      removedTags.add(viewTag);
       shareableViewDescriptors.modify((descriptors) => {
         'worklet';
         const index = descriptors.findIndex(

--- a/packages/react-native-reanimated/src/commonTypes.ts
+++ b/packages/react-native-reanimated/src/commonTypes.ts
@@ -267,6 +267,10 @@ export interface Mutable<Value = unknown> extends SharedValue<Value> {
   _value: Value;
 }
 
+export type StyleUpdaterContainer = {
+  current: ((forceUpdate: boolean) => void) | undefined;
+};
+
 // The below type is used for HostObjects returned by the JSI API that don't have
 // any accessible fields or methods but can carry data that is accessed from the
 // c++ side. We add a field to the type to make it possible for typescript to recognize

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -7,6 +7,7 @@ import type {
   ShadowNodeWrapper,
   SharedValue,
   StyleProps,
+  StyleUpdaterContainer,
 } from '../commonTypes';
 import type { SkipEnteringContext } from '../component/LayoutAnimationConfig';
 import type { ViewConfig } from '../ConfigHelper';
@@ -19,6 +20,7 @@ import type { ViewDescriptorsSet } from '../ViewDescriptorsSet';
 export interface AnimatedProps extends Record<string, unknown> {
   viewDescriptors?: ViewDescriptorsSet;
   initial?: SharedValue<StyleProps>;
+  styleUpdaterContainer?: StyleUpdaterContainer;
 }
 
 export interface ViewInfo {

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -581,11 +581,14 @@ export function createAnimatedComponent(
 
       // attach animatedProps property
       if (this.props.animatedProps?.viewDescriptors) {
-        this.props.animatedProps.viewDescriptors.add({
-          tag: viewTag as number,
-          name: viewName!,
-          shadowNodeWrapper: shadowNodeWrapper!,
-        });
+        this.props.animatedProps.viewDescriptors.add(
+          {
+            tag: viewTag as number,
+            name: viewName!,
+            shadowNodeWrapper: shadowNodeWrapper!,
+          },
+          this.props.animatedProps.styleUpdaterContainer
+        );
       }
     }
 

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -550,11 +550,14 @@ export function createAnimatedComponent(
       }
 
       newStyles.forEach((style) => {
-        style.viewDescriptors.add({
-          tag: viewTag,
-          name: viewName,
-          shadowNodeWrapper,
-        });
+        style.viewDescriptors.add(
+          {
+            tag: viewTag,
+            name: viewName,
+            shadowNodeWrapper,
+          },
+          style.styleUpdaterContainer
+        );
         if (IS_JEST) {
           /**
            * We need to connect Jest's TestObject instance whose contains just

--- a/packages/react-native-reanimated/src/hook/commonTypes.ts
+++ b/packages/react-native-reanimated/src/hook/commonTypes.ts
@@ -13,6 +13,7 @@ import type {
   AnimatedStyle,
   ShadowNodeWrapper,
   SharedValue,
+  StyleUpdaterContainer,
   WorkletFunction,
 } from '../commonTypes';
 import type { AnimatedProps } from '../createAnimatedComponent/commonTypes';
@@ -104,6 +105,7 @@ export interface AnimatedStyleHandle<
     value: AnimatedStyle<Style>;
     updater: () => AnimatedStyle<Style>;
   };
+  styleUpdaterContainer?: StyleUpdaterContainer;
 }
 
 export interface JestAnimatedStyleHandle<

--- a/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
@@ -11,6 +11,7 @@ import type {
   NestedObjectValues,
   SharedValue,
   StyleProps,
+  StyleUpdaterContainer,
   Timestamp,
   WorkletFunction,
 } from '../commonTypes';
@@ -56,6 +57,7 @@ interface AnimatedUpdaterData {
   };
   remoteState: AnimatedState;
   viewDescriptors: ViewDescriptorsSet;
+  styleUpdaterContainer: StyleUpdaterContainer;
 }
 
 function prepareAnimation(
@@ -203,7 +205,8 @@ function styleUpdater(
   updater: WorkletFunction<[], AnimatedStyle<any>> | (() => AnimatedStyle<any>),
   state: AnimatedState,
   animationsActive: SharedValue<boolean>,
-  isAnimatedProps = false
+  isAnimatedProps = false,
+  forceUpdate?: boolean
 ): void {
   'worklet';
   const animations = state.animations ?? {};
@@ -301,7 +304,7 @@ function styleUpdater(
     state.isAnimationCancelled = true;
     state.animations = [];
 
-    if (!shallowEqual(oldValues, newValues)) {
+    if (!shallowEqual(oldValues, newValues) || forceUpdate) {
       updateProps(viewDescriptors, newValues, isAnimatedProps);
     }
   }
@@ -314,7 +317,8 @@ function jestStyleUpdater(
   state: AnimatedState,
   animationsActive: SharedValue<boolean>,
   animatedValues: MutableRefObject<AnimatedStyle<any>>,
-  adapters: AnimatedPropsAdapterFunction[]
+  adapters: AnimatedPropsAdapterFunction[],
+  forceUpdate?: boolean
 ): void {
   'worklet';
   const animations: AnimatedStyle<any> = state.animations ?? {};
@@ -398,7 +402,7 @@ function jestStyleUpdater(
   // calculate diff
   state.last = newValues;
 
-  if (!shallowEqual(oldValues, newValues)) {
+  if (!shallowEqual(oldValues, newValues) || forceUpdate) {
     updatePropsJestWrapper(
       viewDescriptors,
       newValues,
@@ -525,27 +529,12 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
         isFirstRun: true,
       }),
       viewDescriptors: makeViewDescriptorsSet(),
+      styleUpdaterContainer: { current: undefined },
     };
   }
 
   const { initial, remoteState, viewDescriptors } = animatedUpdaterData.current;
   const shareableViewDescriptors = viewDescriptors.shareableViewDescriptors;
-
-  const forceUpdateStyle = () => {
-    'worklet';
-    // Reset last so shallowEqual fails and styleUpdater re-applies current values.
-    // This handles both plain values (sv.value) and animated values (withTiming etc.)
-    // correctly without passing raw animation objects to updateProps directly.
-    remoteState.last = {};
-    styleUpdater(
-      shareableViewDescriptors,
-      updater as WorkletFunction<[], AnimatedStyle<any>>,
-      remoteState,
-      areAnimationsActive,
-      isAnimatedProps
-    );
-  };
-  viewDescriptors.setForceUpdate(forceUpdateStyle as unknown as () => void);
 
   dependencies.push(shareableViewDescriptors);
 
@@ -564,7 +553,7 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
     }
 
     if (isJest()) {
-      fun = () => {
+      fun = (forceUpdate?: boolean) => {
         'worklet';
         jestStyleUpdater(
           shareableViewDescriptors,
@@ -572,18 +561,20 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
           remoteState,
           areAnimationsActive,
           jestAnimatedValues,
-          adaptersArray
+          adaptersArray,
+          forceUpdate
         );
       };
     } else {
-      fun = () => {
+      fun = (forceUpdate?: boolean) => {
         'worklet';
         styleUpdater(
           shareableViewDescriptors,
           updaterFn,
           remoteState,
           areAnimationsActive,
-          isAnimatedProps
+          isAnimatedProps,
+          forceUpdate
         );
       };
       if (
@@ -604,6 +595,9 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
           })();
         });
       }
+    }
+    if (animatedUpdaterData.current) {
+      animatedUpdaterData.current.styleUpdaterContainer.current = fun;
     }
     const mapperId = startMapper(fun, inputs);
     return () => {
@@ -631,14 +625,44 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
   >(null);
 
   if (!animatedStyleHandle.current) {
-    animatedStyleHandle.current = isJest()
-      ? {
-          viewDescriptors,
-          initial,
-          jestAnimatedValues,
-          toJSON: animatedStyleHandleToJSON,
-        }
-      : { viewDescriptors, initial };
+    const styleUpdaterContainer =
+      animatedUpdaterData.current.styleUpdaterContainer;
+    if (__DEV__) {
+      // In DEV, React Native's deepFreezeAndThrowOnMutationInDev recursively
+      // freezes every prop value of native views using Object.keys. If the
+      // animated handle is reachable from such a prop, styleUpdaterContainer
+      // gets frozen before useEffect can write `current = fun`.
+      // Making it non-enumerable hides it from Object.keys while keeping it
+      // fully accessible by name (e.g. in createAnimatedComponent).
+      // In production deepFreezeAndThrowOnMutationInDev is a no-op, so the
+      // plain object literal below is safe.
+      const handle = isJest()
+        ? {
+            viewDescriptors,
+            initial,
+            jestAnimatedValues,
+            toJSON: animatedStyleHandleToJSON,
+          }
+        : { viewDescriptors, initial };
+      Object.defineProperty(handle, 'styleUpdaterContainer', {
+        value: styleUpdaterContainer,
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      });
+      animatedStyleHandle.current =
+        handle as typeof handle & { styleUpdaterContainer: StyleUpdaterContainer };
+    } else {
+      animatedStyleHandle.current = isJest()
+        ? {
+            viewDescriptors,
+            initial,
+            jestAnimatedValues,
+            toJSON: animatedStyleHandleToJSON,
+            styleUpdaterContainer,
+          }
+        : { viewDescriptors, initial, styleUpdaterContainer };
+    }
   }
 
   return animatedStyleHandle.current;

--- a/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
+++ b/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts
@@ -531,6 +531,22 @@ For more, see the docs: \`https://docs.swmansion.com/react-native-reanimated/doc
   const { initial, remoteState, viewDescriptors } = animatedUpdaterData.current;
   const shareableViewDescriptors = viewDescriptors.shareableViewDescriptors;
 
+  const forceUpdateStyle = () => {
+    'worklet';
+    // Reset last so shallowEqual fails and styleUpdater re-applies current values.
+    // This handles both plain values (sv.value) and animated values (withTiming etc.)
+    // correctly without passing raw animation objects to updateProps directly.
+    remoteState.last = {};
+    styleUpdater(
+      shareableViewDescriptors,
+      updater as WorkletFunction<[], AnimatedStyle<any>>,
+      remoteState,
+      areAnimationsActive,
+      isAnimatedProps
+    );
+  };
+  viewDescriptors.setForceUpdate(forceUpdateStyle as unknown as () => void);
+
   dependencies.push(shareableViewDescriptors);
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

PR backporting https://github.com/software-mansion/react-native-reanimated/pull/7742 to our fork since it was never added to v3. Should fix https://app.asana.com/1/236888843494340/project/1199705967702853/task/1213321162214219. Basically it triggers the style updates after readding the views that were unmounted for the duration of `react-freeze`.

