### PR TITLE
fix(ios): ios new arch deadlock fix

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -896,14 +896,6 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
     // way but backgroundColor, shadowOpacity etc. would get overwritten (see
     // `_propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN`).
     for (const auto &[shadowNode, props] : copiedOperationsQueue) {
-        auto tag = shadowNode->getTag();
-        
-        // Pass the JSI object directly
-        bool hasLayoutUpdates = updateNoneLayoutProps(rt, props->asObject(rt), tag);
-        if (hasLayoutUpdates) {
-            layoutUpdatesByTag.insert(tag);
-        }
-        
         // Still need to convert to dynamic for propsRegistry
         folly::dynamic propsDynamic = dynamicFromValue(rt, *props);
 
@@ -916,6 +908,15 @@ void ReanimatedModuleProxy::performOperations(const bool isTriggeredByEvent, con
   }
 
   for (const auto &[shadowNode, props] : copiedOperationsQueue) {
+    auto tag = shadowNode->getTag();
+
+    // Update layout props outside of the propsRegistry lock, as it can be re-entrant,
+    // see: https://app.asana.com/1/236888843494340/project/1199705967702853/task/1214021546045556?focus=true
+    bool hasLayoutUpdates = updateNoneLayoutProps(rt, props->asObject(rt), tag);
+    if (hasLayoutUpdates) {
+      layoutUpdatesByTag.insert(tag);
+    }
+
     const jsi::Value &nonAnimatableProps = filterNonAnimatableProps(rt, *props);
     if (nonAnimatableProps.isUndefined()) {
       continue;


### PR DESCRIPTION
On iOS new arch I ran into a case where the `updateSyncLayoutProps` fast-path can be re-entrant into `::performOperations` as the first update potentially triggers an event that we handle sync:

<img width="1701" height="1254" alt="Screenshot 2026-04-15 at 14 50 17" src="https://github.com/user-attachments/assets/7ad28bbf-5214-44c6-afa3-5ae3fbf6d568" />

Ticket: https://app.asana.com/1/236888843494340/project/1199705967702853/task/1214021546045556

My fix is to move the sync update fast-path out of the lock. We only need that lock to access the props registry. I _think_ applying the updates off the lock should be safe.