### PR TITLE
Revert "feat(reanimated): prevent style detachment for components fro…

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.cpp
@@ -2,7 +2,6 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #include <reanimated/Fabric/PropsRegistry.h>
-#include <cstring>
 
 namespace reanimated {
 
@@ -65,43 +64,18 @@ void PropsRegistry::unmarkNodeAsRemovable(Tag viewTag) {
   removableShadowNodes_.erase(viewTag);
 }
 
-void PropsRegistry::handleNodeRemovals(
-    const RootShadowNode &rootShadowNode,
-    const NodeRemovalCallback &callback) {
+void PropsRegistry::handleNodeRemovals(const RootShadowNode &rootShadowNode) {
   RemovableShadowNodes remainingShadowNodes;
 
   for (const auto &[tag, shadowNode] : removableShadowNodes_) {
     if (!shadowNode) {
-      // Stopgap for bad shadowNode
-      map_.erase(tag);
       continue;
     }
 
-    const auto &family = shadowNode->getFamily();
-    const auto &ancestors = family.getAncestors(rootShadowNode);
-
-    // Determine if component is frozen
-    // isFrozen=true means component still has parents (with Suspense parent being one of them)
-    // isFrozen=false means component is truly unmounting
-    bool isFrozen = false;
-    for (const auto &[parentNode, _] : ancestors) {
-      const auto parentComponentName = parentNode.get().getComponentName();
-      if (strstr(parentComponentName, "Suspense") != nullptr) {
-        isFrozen = true;
-        break;
-      }
-    }
-
-    // Notify JavaScript about the freeze decision
-    if (callback) {
-      callback(tag, isFrozen);
-    }
-
-    // PropsRegistry decision: keep if has ancestors, remove if no ancestors
-    if (!ancestors.empty()) {
-      remainingShadowNodes.emplace(tag, shadowNode);
-    } else {
+    if (shadowNode->getFamily().getAncestors(rootShadowNode).empty()) {
       map_.erase(tag);
+    } else {
+      remainingShadowNodes.emplace(tag, shadowNode);
     }
   }
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/PropsRegistry.h
@@ -13,8 +13,6 @@ using namespace react;
 
 namespace reanimated {
 
-using NodeRemovalCallback = std::function<void(Tag tag, bool isFrozen)>;
-
 class PropsRegistry {
  public:
   std::lock_guard<std::mutex> createLock() const;
@@ -68,9 +66,7 @@ class PropsRegistry {
 
   void markNodeAsRemovable(const std::shared_ptr<const ShadowNode> &shadowNode);
   void unmarkNodeAsRemovable(Tag viewTag);
-  void handleNodeRemovals(
-      const RootShadowNode &rootShadowNode,
-      const NodeRemovalCallback &callback = nullptr);
+  void handleNodeRemovals(const RootShadowNode &rootShadowNode);
 
   // Custom discord added for removing nodes once they seem in sync with the shadow tree
   void markNodeAsImmediateRemovable(Tag tag);

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -2,15 +2,13 @@
 
 #include <reanimated/Fabric/ReanimatedCommitShadowNode.h>
 #include <reanimated/Fabric/ReanimatedMountHook.h>
-#include <reanimated/NativeModules/ReanimatedModuleProxy.h>
 
 namespace reanimated {
 
 ReanimatedMountHook::ReanimatedMountHook(
     const std::shared_ptr<PropsRegistry> &propsRegistry,
-    const std::shared_ptr<UIManager> &uiManager,
-    const std::shared_ptr<ReanimatedModuleProxy> &moduleProxy)
-    : propsRegistry_(propsRegistry), uiManager_(uiManager), moduleProxy_(moduleProxy) {
+    const std::shared_ptr<UIManager> &uiManager)
+    : propsRegistry_(propsRegistry), uiManager_(uiManager) {
   uiManager_->registerMountHook(*this);
 }
 
@@ -42,15 +40,7 @@ void ReanimatedMountHook::shadowTreeDidMount(
 
   {
     auto lock = propsRegistry_->createLock();
-
-    // Create callback to notify JavaScript about node removal decisions
-    auto callback = [this](Tag tag, bool isFrozen) {
-      auto moduleProxy = moduleProxy_.lock();
-      if (moduleProxy) {
-        moduleProxy->onNodeRemovalDecision(tag, isFrozen);
-      }
-    };
-    propsRegistry_->handleNodeRemovals(*rootShadowNode, callback);
+    propsRegistry_->handleNodeRemovals(*rootShadowNode);
 
     // When commit from React Native has finished, we reset the skip commit flag
     // in order to allow Reanimated to commit its tree

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.h
@@ -12,15 +12,11 @@ namespace reanimated {
 
 using namespace facebook::react;
 
-// Forward declaration
-class ReanimatedModuleProxy;
-
 class ReanimatedMountHook : public UIManagerMountHook {
  public:
   ReanimatedMountHook(
       const std::shared_ptr<PropsRegistry> &propsRegistry,
-      const std::shared_ptr<UIManager> &uiManager,
-      const std::shared_ptr<ReanimatedModuleProxy> &moduleProxy);
+      const std::shared_ptr<UIManager> &uiManager);
   ~ReanimatedMountHook() noexcept override;
 
   void shadowTreeDidMount(
@@ -35,7 +31,6 @@ class ReanimatedMountHook : public UIManagerMountHook {
  private:
   const std::shared_ptr<PropsRegistry> propsRegistry_;
   const std::shared_ptr<UIManager> uiManager_;
-  const std::weak_ptr<ReanimatedModuleProxy> moduleProxy_;
 };
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -1107,7 +1107,7 @@ void ReanimatedModuleProxy::initializeFabric(
   initializeLayoutAnimationsProxy();
 
   mountHook_ =
-      std::make_shared<ReanimatedMountHook>(propsRegistry_, uiManager_, shared_from_this());
+      std::make_shared<ReanimatedMountHook>(propsRegistry_, uiManager_);
   commitHook_ = std::make_shared<ReanimatedCommitHook>(
       propsRegistry_, uiManager_, layoutAnimationsProxy_);
 }
@@ -1191,27 +1191,5 @@ void ReanimatedModuleProxy::unsubscribeFromKeyboardEvents(
     const jsi::Value &listenerId) {
   unsubscribeFromKeyboardEventsFunction_(listenerId.asNumber());
 }
-
-#ifdef RCT_NEW_ARCH_ENABLED
-void ReanimatedModuleProxy::setNodeRemovalCallback(
-    jsi::Runtime &rt,
-    const jsi::Value &callback) {
-  if (callback.isObject() && callback.asObject(rt).isFunction(rt)) {
-    nodeRemovalCallback_ = react::AsyncCallback<>(
-        rt,
-        callback.asObject(rt).asFunction(rt),
-        jsInvoker_);
-  }
-}
-
-void ReanimatedModuleProxy::onNodeRemovalDecision(Tag tag, bool isFrozen) {
-  if (nodeRemovalCallback_) {
-    // Use custom lambda to manually convert to JSI values (JSI supports int/bool via jsi::Value)
-    nodeRemovalCallback_->call([tag, isFrozen](jsi::Runtime& rt, jsi::Function& callback) {
-      callback.call(rt, jsi::Value(static_cast<int>(tag)), jsi::Value(isFrozen));
-    });
-  }
-}
-#endif // RCT_NEW_ARCH_ENABLED
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.h
@@ -10,7 +10,6 @@
 #include <reanimated/Fabric/ReanimatedCommitHook.h>
 #include <reanimated/Fabric/ReanimatedMountHook.h>
 #include <reanimated/LayoutAnimations/LayoutAnimationsProxy.h>
-#include <react/bridging/Function.h>
 #endif // RCT_NEW_ARCH_ENABLED
 
 #include <worklets/NativeModules/WorkletsModuleProxy.h>
@@ -131,10 +130,6 @@ class ReanimatedModuleProxy
       const jsi::Value &shadowNodeWrapper) override;
   void unmarkNodeAsRemovable(jsi::Runtime &rt, const jsi::Value &viewTag)
       override;
-
-  void setNodeRemovalCallback(jsi::Runtime &rt, const jsi::Value &callback)
-      override;
-  void onNodeRemovalDecision(Tag tag, bool isFrozen);
 
   void dispatchCommand(
       jsi::Runtime &rt,
@@ -260,9 +255,6 @@ class ReanimatedModuleProxy
 
   const SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction_;
   std::unordered_set<std::string> nativePropNames_; // filled by configureProps
-
-  // Node removal callback for freeze detection
-  std::optional<react::AsyncCallback<>> nodeRemovalCallback_;
 #else
   const ObtainPropFunction obtainPropFunction_;
   const ConfigurePropsFunction configurePropsPlatformFunction_;

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.cpp
@@ -182,16 +182,6 @@ static jsi::Value REANIMATED_SPEC_PREFIX(unmarkNodeAsRemovable)(
   return jsi::Value::undefined();
 }
 
-static jsi::Value REANIMATED_SPEC_PREFIX(setNodeRemovalCallback)(
-    jsi::Runtime &rt,
-    TurboModule &turboModule,
-    const jsi::Value *args,
-    size_t) {
-  static_cast<ReanimatedModuleProxySpec *>(&turboModule)
-      ->setNodeRemovalCallback(rt, std::move(args[0]));
-  return jsi::Value::undefined();
-}
-
 static jsi::Value REANIMATED_SPEC_PREFIX(
     getSettledUpdates)(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value *args, size_t) {
   return static_cast<ReanimatedModuleProxySpec *>(&turboModule)->getSettledUpdates(rt);
@@ -241,8 +231,6 @@ ReanimatedModuleProxySpec::ReanimatedModuleProxySpec(
       MethodMetadata{1, REANIMATED_SPEC_PREFIX(markNodeAsRemovable)};
   methodMap_["unmarkNodeAsRemovable"] =
       MethodMetadata{1, REANIMATED_SPEC_PREFIX(unmarkNodeAsRemovable)};
-  methodMap_["setNodeRemovalCallback"] =
-      MethodMetadata{1, REANIMATED_SPEC_PREFIX(setNodeRemovalCallback)};
   methodMap_["getSettledUpdates"] =
       MethodMetadata{1, REANIMATED_SPEC_PREFIX(getSettledUpdates)};
 #endif // RCT_NEW_ARCH_ENABLED

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxySpec.h
@@ -103,9 +103,6 @@ class JSI_EXPORT ReanimatedModuleProxySpec : public TurboModule {
   virtual void unmarkNodeAsRemovable(
       jsi::Runtime &rt,
       const jsi::Value &viewTag) = 0;
-  virtual void setNodeRemovalCallback(
-      jsi::Runtime &rt,
-      const jsi::Value &callback) = 0;
   virtual jsi::Value getSettledUpdates(jsi::Runtime &rt) = 0;
 #endif // RCT_NEW_ARCH_ENABLED
 };

--- a/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/NativeReanimated.ts
@@ -197,10 +197,6 @@ See https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooti
     this.#reanimatedModuleProxy.unmarkNodeAsRemovable(viewTag);
   }
 
-  setNodeRemovalCallback(callback: (tag: number, isFrozen: boolean) => void) {
-    this.#reanimatedModuleProxy.setNodeRemovalCallback(callback);
-  }
-
   getSettledUpdates(): SettledUpdate[] {
     return this.#reanimatedModuleProxy.getSettledUpdates();
   }
@@ -228,7 +224,6 @@ class DummyReanimatedModuleProxy implements ReanimatedModuleProxy {
   unsubscribeFromKeyboardEvents(): void {}
   markNodeAsRemovable(): void {}
   unmarkNodeAsRemovable(): void {}
-  setNodeRemovalCallback(): void {}
 
   registerSensor(): number {
     return -1;

--- a/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/js-reanimated/JSReanimated.ts
@@ -319,14 +319,6 @@ class JSReanimated implements IReanimatedModule {
       'unmarkNodeAsRemovable is not available in JSReanimated.'
     );
   }
-
-  setNodeRemovalCallback(
-    _callback: (tag: number, isFrozen: boolean) => void
-  ): void {
-    throw new ReanimatedError(
-      'setNodeRemovalCallback is not available in JSReanimated.'
-    );
-  }
 }
 
 // Lack of this export breaks TypeScript generation since

--- a/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
+++ b/packages/react-native-reanimated/src/ReanimatedModule/reanimatedModuleProxy.ts
@@ -71,9 +71,5 @@ export interface ReanimatedModuleProxy {
   markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper): void;
   unmarkNodeAsRemovable(viewTag: number): void;
 
-  setNodeRemovalCallback(
-    callback: (tag: number, isFrozen: boolean) => void
-  ): void;
-
   getSettledUpdates(): SettledUpdate[];
 }

--- a/packages/react-native-reanimated/src/core.ts
+++ b/packages/react-native-reanimated/src/core.ts
@@ -230,11 +230,3 @@ export function markNodeAsRemovable(shadowNodeWrapper: ShadowNodeWrapper) {
 export function unmarkNodeAsRemovable(viewTag: number) {
   ReanimatedModule.unmarkNodeAsRemovable(viewTag);
 }
-
-export function setNodeRemovalCallback(
-  callback: (tag: number, isFrozen: boolean) => void
-) {
-  if (isFabric()) {
-    ReanimatedModule.setNodeRemovalCallback(callback);
-  }
-}

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -130,19 +130,13 @@ export interface IAnimatedComponentInternal {
   _NativeEventsManager?: INativeEventsManager;
   _viewInfo?: ViewInfo;
   context: React.ContextType<typeof SkipEnteringContext>;
-  _willUnmount: boolean;
   /**
    * Used for Shared Element Transitions, Layout Animations and Animated Styles.
    * It is not related to event handling.
    */
   getComponentViewTag: () => number;
-  /**
-   * A function that will update the components state (the state is used for the
-   * style prop)
-   */
+  /** A function that will update the components state (the state is used for the style prop) */
   _updateReanimatedProps: (props: StyleProps) => void;
-  /** Detach styles from view descriptors */
-  _detachStyles: () => void;
 
   _syncStylePropsBackToReact: (props: StyleProps) => void;
 }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -24,7 +24,6 @@ import { adaptViewConfig } from '../ConfigHelper';
 import {
   enableLayoutAnimations,
   markNodeAsRemovable,
-  setNodeRemovalCallback,
   unmarkNodeAsRemovable,
 } from '../core';
 import { ReanimatedError } from '../errors';
@@ -54,7 +53,6 @@ import { PropsRegistryGarbageCollector } from '../PropsRegistryGarbageCollector'
 import { componentWithRef } from '../reactUtils';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
 import { updateLayoutAnimations } from '../UpdateLayoutAnimations';
-import { ComponentRegistry } from '../updateProps/ComponentRegistry';
 import type {
   AnimatedComponentProps,
   AnimatedComponentRef,
@@ -73,6 +71,7 @@ import { NativeEventsManager } from './NativeEventsManager';
 import { PropsFilter } from './PropsFilter';
 import setAndForwardRef from './setAndForwardRef';
 import { flattenArray } from './utils';
+import { ComponentRegistry } from '../updateProps/ComponentRegistry';
 
 const IS_WEB = isWeb();
 const IS_JEST = isJest();
@@ -83,27 +82,6 @@ if (IS_WEB) {
   configureWebLayoutAnimations();
 }
 
-// Register callback for freeze detection (Fabric only)
-// Extends PR #7316's markNodeAsRemovable infrastructure with Suspense-based freeze detection
-if (isFabric()) {
-  setNodeRemovalCallback((tag: number, isFrozen: boolean) => {
-    const component = ComponentRegistry.getComponent(tag);
-    if (!component || !component._willUnmount) {
-      // Skip if component doesn't exist or already handled (remounted before callback fired)
-      return;
-    }
-
-    if (!isFrozen) {
-      // Component truly unmounted - safe to clean up
-      component._detachStyles();
-      ComponentRegistry.unregister(tag);
-    }
-
-    // Always clear flag whether frozen or unmounted
-    component._willUnmount = false;
-  });
-}
-
 function onlyAnimatedStyles(styles: StyleProps[]): StyleProps[] {
   return styles.filter((style) => style?.viewDescriptors);
 }
@@ -111,9 +89,9 @@ function onlyAnimatedStyles(styles: StyleProps[]): StyleProps[] {
 type Options<P> = {
   setNativeProps?: (ref: AnimatedComponentRef, props: P) => void;
   /**
-   * Discord enables a performance improvement, which causes us to sync back any
-   * animated props from the UI thread back to react JS. Switching this to
-   * `true` disables this behavior. Default is `false`.
+   * Discord enables a performance improvement, which causes us to sync back any animated props from the UI thread
+   * back to react JS.
+   * Switching this to `true` disables this behavior. Default is `false`.
    */
   disableReactSync?: boolean;
 };
@@ -151,7 +129,7 @@ export function createAnimatedComponent<P extends object>(
 // @ts-ignore This is required to create this overload, since type of createAnimatedComponent is incorrect and doesn't include typeof FlatList
 export function createAnimatedComponent(
   component: typeof FlatList<unknown>,
-  options?: Options<FlatListProps<unknown>>
+  options?: Options<any>
 ): ComponentClass<AnimateProps<FlatListProps<unknown>>>;
 
 let id = 0;
@@ -159,9 +137,7 @@ let id = 0;
 export function createAnimatedComponent(
   Component: ComponentType<InitialComponentProps>,
   options?: Options<InitialComponentProps>
-):
-  | FunctionComponent<AnimateProps<InitialComponentProps>>
-  | ComponentClass<AnimateProps<InitialComponentProps>> {
+): any {
   if (!IS_REACT_19) {
     invariant(
       typeof Component !== 'function' ||
@@ -209,6 +185,7 @@ export function createAnimatedComponent(
 
       this.state = { settledProps: {}, reanimatedProps: {} };
 
+      const entering = this.props.entering;
       const skipEntering = this.context?.current;
       if (isFabric() && !skipEntering) {
         this._configureLayoutAnimation(
@@ -291,8 +268,6 @@ export function createAnimatedComponent(
         this._willUnmount &&
         typeof viewTag === 'number'
       ) {
-        // Component was frozen and is now remounting - cancel pending cleanup
-        this._willUnmount = false;
         unmarkNodeAsRemovable(viewTag);
       }
 
@@ -308,15 +283,7 @@ export function createAnimatedComponent(
         PropsRegistryGarbageCollector.unregisterView(viewTag);
       }
 
-      // Defer cleanup for Fabric (freeze detection via callback), immediate for Paper/Web
-      if (!SHOULD_BE_USE_WEB && isFabric()) {
-        // Mark as unmounting - callback will determine if frozen or truly unmounted
-        this._willUnmount = true;
-      } else {
-        // Paper/Web: Can't distinguish freeze from unmount, clean up immediately
-        this._detachStyles();
-      }
-
+      this._detachStyles();
       this._InlinePropManager.detachInlineProps();
       if (this.props.sharedTransitionTag) {
         this._configureSharedTransition(true);
@@ -327,9 +294,7 @@ export function createAnimatedComponent(
       );
 
       const exiting = this.props.exiting;
-
-      // Unregister from ComponentRegistry (Paper only - Fabric handled in callback)
-      if (!SHOULD_BE_USE_WEB && !isFabric() && viewTag !== -1) {
+      if (viewTag !== -1) {
         ComponentRegistry.unregister(viewTag);
       }
 
@@ -364,6 +329,8 @@ export function createAnimatedComponent(
         // remounted (e.g., when frozen) after componentWillUnmount is called.
         markNodeAsRemovable(wrapper);
       }
+
+      this._willUnmount = true;
     }
 
     _syncStylePropsBackToReact(props: StyleProps) {
@@ -398,31 +365,25 @@ export function createAnimatedComponent(
     }
 
     /**
-     * Mechanism to update this component's props from native.Add commentMore
-     * actions (As reanimated is changing the props only on the UI thread at
-     * some point we want to sync with the JS thread). Reanimated props can be
-     * animatedProps but also animated styles. Note that styles are flattened
-     * and passed as top level props.
+     * Mechanism to update this component's props from native.Add commentMore actions
+     * (As reanimated is changing the props only on the UI thread at some point we want to sync with the JS thread).
+     * Reanimated props can be animatedProps but also animated styles. Note that styles are flattened and passed as top level props.
      */
-    _updateReanimatedProps(props: { [key: string]: unknown }) {
+    _updateReanimatedProps(props: {[key: string]: unknown}) {
       if (options?.disableReactSync) {
         return;
       }
 
-      const transformedProps: { [key: string]: unknown } = {};
+      const transformedProps: {[key: string]: unknown} = {};
       for (const prop in props) {
         let value = props[prop];
-        if (
-          (prop === 'color' || prop.endsWith('Color')) &&
-          value &&
-          typeof value === 'string'
-        ) {
+        if ((prop === 'color' || prop.endsWith('Color')) && value && typeof value === 'string') {
           value = processColor(value);
         } else if (
-          prop === 'top' ||
-          prop === 'bottom' ||
-          prop.startsWith('margin') ||
-          prop.startsWith('padding')
+          prop == 'top'
+          || prop == 'bottom'
+          || prop.startsWith('margin')
+          || prop.startsWith('padding')
         ) {
           // if all reanimated props cannot be updated, there is no point in syncing them
           return;
@@ -460,9 +421,9 @@ export function createAnimatedComponent(
       } else {
         const hostInstance = findHostInstance(this);
         if (!hostInstance) {
-          /*
-            findHostInstance can return null for a component that doesn't render anything
-            (render function returns null). Example:
+          /* 
+            findHostInstance can return null for a component that doesn't render anything 
+            (render function returns null). Example: 
             svg Stop: https://github.com/react-native-svg/react-native-svg/blob/develop/src/elements/Stop.tsx
           */
           throw new ReanimatedError(


### PR DESCRIPTION
Reverts:

- https://github.com/discord/react-native-reanimated/pull/14

Instead, for freeze handling we fully rely on:

- https://github.com/software-mansion/react-native-reanimated/pull/7316
- https://github.com/software-mansion/react-native-reanimated/pull/7742

**Before**

Before we would keep the component descriptors of components that are frozen.
Then, a layout prop animation happens to a frozen view, e.g. animating `height`. `updateProps` would be called, a commit to shadowTree happens - but - when the shadow tree calls `RootShadowNode::layoutIfNeeded` it will basically **stop** processing the layout at the suspense boundary, since react-native reconciler marks it with `display: none` (and react native's layout algorithm doesn't go deeper into the tree if one view has `display: none`):

https://github.com/facebook/react-native/blob/bc1a31fb16f0cf1ca92331499c6f2fa4e347dfbf/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp#L731-L732

This is an issue because effectively this layout change now got dropped and will never get reapplied.
This caused for example:
- https://app.asana.com/1/236888843494340/project/1197438383943832/task/1212416709800091?focus=true
- https://app.asana.com/1/236888843494340/project/1211296341662376/task/1211215533034093?focus=true

**After these changes**

Since then fixes have landed in reanimated, and we CPed those fixes to our v3 fork.
With those fixes, we basically unregister a animated view's component descriptor on freeze (as the class component wrapper `componentWillUnmount` will fire on freeze / or unmount).
However, now, when the component unfreezes its descriptor is added again.
This has always happened on the v3 branch - but - when we originally made #14 we didn't had - https://github.com/software-mansion/react-native-reanimated/pull/7742 in place which fixes the problem more elegantly: 

When the descriptor is added back we will run its style updater function and pass `forceUpdate` which will "recompute" the useAnimatedStyle and call updateProps again.
With that our view will correctly update once unfrozen.

I think this is the proper approach to the problem (this fix is only on v4 upstream but we since have CPed it)