### PR TITLE
Cherry-pick: Fix sync props back to React mechanism

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -334,7 +334,9 @@ export function createAnimatedComponent(
     }
 
     _syncStylePropsBackToReact(props: StyleProps) {
-      this.setState({ settledProps: props });
+      this.setState((state) => ({
+        settledProps: { ...state.settledProps, ...props },
+      }));
     }
 
     getComponentViewTag() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

<!-- Explain the motivation for this PR. Include "Fixes #<number>" if applicable. -->

Cherry-pick fix from the upstream: https://github.com/software-mansion/react-native-reanimated/commit/4d7091645d83a8c27eed45142660e8bef1fa6e2d to fix https://app.asana.com/1/236888843494340/project/1211939083829359/task/1215154868859952?focus=true
