### PR TITLE
fix(Fabric): whitelist svg `fill` as a UI-thread prop to stop color flicker/stepping

### DIFF
--- a/packages/react-native-reanimated/src/propsAllowlists.ts
+++ b/packages/react-native-reanimated/src/propsAllowlists.ts
@@ -50,7 +50,8 @@ export const PropsAllowlists: AllowlistsHolder = {
     translateX: true,
     translateY: true,
     /* text props */
-    ...(isFabric ? textProps : {})
+    ...(isFabric ? textProps : {}),
+    fill: true,
   },
   /**
    * Whitelist of view props that can be updated in native thread via


### PR DESCRIPTION
## Summary

Add `fill` to Reanimated's UI-thread prop allowlist so animating a `react-native-svg` color prop (`fill`) via `useAnimatedProps` runs on the **UI thread on both iOS and Android Fabric**, instead of falling back to the throttled JS `setNativeProps` sync path.

In the Discord app this is the voice-message record button: while recording, the blurple ellipse flickers **red** on iOS and shows coarse color **stepping** on Android as the wave animates.

```ts
// packages/react-native-reanimated/src/propsAllowlists.ts (UI_THREAD_PROPS_WHITELIST)
...(isFabric ? textProps : {}),
fill: true,
```

## Root cause

`fill` was not present in `UI_THREAD_PROPS_WHITELIST`.

- On **iOS** the SVG view config exposes `fill` via `adaptViewConfig`, so it happens to animate on the UI thread.
- On **Android Fabric** `fill` is not exposed that way, so without this entry it falls back to the JS `updateJSProps` → `_updateFromNative` → `component.setNativeProps({ fill })` path. That path is throttled (~15fps), which produces the visible color **stepping**.

That same JS path is also where the **red flash** comes from. Props coming back from native are already processed (colors are packed ARGB ints, blurple = `0xFF5865F2`), but `setNativeProps` is the user-facing API, so `react-native-svg`'s `Shape.setNativeProps` → `extractBrush` → `processColor` processes them **a second time**. `processColor` is a non-idempotent RGBA→ARGB rotation `((c << 24) | (c >>> 8)) >>> 0`, so an already-packed value is rotated again:

```
0xFF5865F2  ->  processColor  ->  0xF2FF5865   (blurple -> red)
```

The correct value is written to the native shadow tree every frame, but the throttled JS `setNativeProps` path races it with the double-processed red → red↔blue flicker while animating; at rest the correct value wins, which is why it only flickers during the animation.

Keeping `fill` on the UI-thread whitelist removes it from that JS `setNativeProps` path entirely, so on both platforms it is applied on the UI thread, once, at 60fps.

## Fix

- **This PR (reanimated):** whitelist `fill: true` in `UI_THREAD_PROPS_WHITELIST`.
- **Complementary app-side change (not in this PR):** the animated `<Ellipse>` is created with `disableReactSync: true` so Reanimated's React sync-back does not commit stale/lagged `fill` values that would clobber the smooth UI-thread animation.

## Runtime evidence (instrumented Android run)

- Before: `_updateFromNative` fires for `fill` on the JS path each frame; `Shape.setNativeProps` receives packed `0xFF5865F2` and `extractBrush`'s `processColor` outputs `0xF2FF5865` (red).
- After whitelisting: `_updateFromNative` / `_updateReanimatedProps` calls carrying `fill` drop to **zero** during the animation — `fill` no longer travels the JS path.
- The React render / settled-props path only ever carried the correct string `rgba(88, 101, 242, 1)`, confirming the render tree was never the source.

## Test plan

Voice-message record button (Fabric + `react-native-svg`), animating `<Ellipse fill>` via `useAnimatedProps` + `interpolateColor` with continuously-updating `rx/ry/cy` to force per-frame updates.

- iOS before: ellipse flashes red while recording. After: stays blurple.
- Android before: color steps coarsely (~15fps). After: smooth 60fps.
- Regression sanity: color-animating standard RN views (e.g. `backgroundColor`) and layout animations behave unchanged.

| iOS | Android |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/5fd1bae9-10f4-4e0f-8be9-348741421268"> | <video src="https://github.com/user-attachments/assets/5fd1bae9-10f4-4e0f-8be9-348741421268"> | 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216245486036040