### PR TITLE
fix: support RN 0.86 host view config

### DIFF
--- a/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
@@ -37,6 +37,6 @@ function getViewInfoLatest(element: any) {
   return {
     viewName: element?._viewConfig?.uiViewClassName,
     viewTag: element?.__nativeTag,
-    viewConfig: element?._viewConfig,
+    viewConfig: (element?.__viewConfig || element?._viewConfig),
   };
 }

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -9,6 +9,8 @@ import { isFabric } from '../PlatformChecker';
 type HostInstanceFabric = {
   __internalInstanceHandle?: Record<string, unknown>;
   __nativeTag?: number;
+  __viewConfig?: Record<string, unknown>;
+  // Legacy ReactFabricHostComponent key (e.g. react-native-macos).
   _viewConfig?: Record<string, unknown>;
 };
 
@@ -26,9 +28,10 @@ function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
   if (
     maybeNativeRef.__internalInstanceHandle &&
     maybeNativeRef.__nativeTag &&
-    maybeNativeRef._viewConfig
+    // ReactFabricHostComponent (e.g. react-native-macos) exposes `_viewConfig`;
+    // ReactNativeElement uses `__viewConfig`.
+    (maybeNativeRef.__viewConfig || maybeNativeRef._viewConfig)
   ) {
-    // This is a native ref to a Fabric component
     return maybeNativeRef;
   }
   if (maybeNativeRef._nativeTag && maybeNativeRef.viewConfig) {


### PR DESCRIPTION
## Description
Support RN 0.86's `ReactNativeElement.__viewConfig` while retaining the legacy `_viewConfig` fallback. This restores dynamic native prop discovery, including SVG props such as `fill`, instead of routing them through the JS fallback.

> [!NOTE]
> This addresses the underlying view-config discovery issue behind #46.

## Test steps
1. Start recording a voice message on iOS and speak continuously.
2. Verify the animated ellipse remains blurple without flickering red.
3. Verify animated SVG props continue working on legacy Fabric host components.

Made with [Cursor](https://cursor.com)