### PR TITLE
fix: support RN 0.86 host view config

### DIFF
--- a/apps/common-app/src/examples/InstanceDiscoveryExample.tsx
+++ b/apps/common-app/src/examples/InstanceDiscoveryExample.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable no-inline-styles/no-inline-styles */
+/* eslint-disable no-useless-constructor */
+/* eslint-disable camelcase */
 import { FlashList } from '@shopify/flash-list';
 import {
   ActivityIndicator,
@@ -17,6 +16,7 @@ import {
   RefreshControl,
   ScrollView,
   SectionList,
+  StyleSheet,
   Switch,
   Text,
   TextInput,
@@ -26,50 +26,33 @@ import {
   // TouchableWithoutFeedback,
   View,
   VirtualizedList,
-  StyleSheet,
-  type ScrollViewProps,
 } from 'react-native';
 import { ScrollView as RNGHScrollView } from 'react-native-gesture-handler';
-import { Path as RNSVGPath } from 'react-native-svg';
 import { makeMutable } from 'react-native-reanimated';
-// @ts-expect-error No types for deep import.
-import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
-import { useCallback } from 'react';
+import { Path as RNSVGPath } from 'react-native-svg';
 
-const findHostInstance_DEPRECATED = ReactFabric.findHostInstance_DEPRECATED as (
-  ref: any
-) => any;
+function isFabric(): boolean {
+  return !!(global as Record<string, unknown>)._IS_FABRIC;
+}
+
+// Conditionally import ReactFabric only on Fabric architecture
+let ReactFabric: any = null;
+if (isFabric()) {
+  try {
+    ReactFabric = require('react-native/Libraries/Renderer/shims/ReactFabric');
+  } catch {
+    // ReactFabric not available
+  }
+}
+
+const findHostInstance_DEPRECATED =
+  ReactFabric?.findHostInstance_DEPRECATED as (ref: any) => any;
 
 // Make sure Reanimated and Worklets are initialized.
 makeMutable(() => {
   'worklet';
   return undefined;
 });
-
-const CustomScrollComponent = (props: ScrollViewProps) => (
-  <View>
-    <ScrollView {...props} />
-  </View>
-);
-
-function FlatListWithCustomRenderer({ data, ref }: { data: any[]; ref: any }) {
-  const renderItem = useCallback((info: any) => {
-    return <Text>{info.item}</Text>;
-  }, []);
-
-  const renderScrollComponent = useCallback((props: ScrollViewProps) => {
-    return <CustomScrollComponent {...props} />;
-  }, []);
-
-  return (
-    <FlatList
-      data={data}
-      ref={ref}
-      renderItem={renderItem}
-      renderScrollComponent={renderScrollComponent}
-    />
-  );
-}
 
 type ImperativeShadowNodeWrapper = {
   source: string;
@@ -108,14 +91,12 @@ let handleToHandleId = new Map<number, number>();
 let shadowNodeWrapperId = 1;
 let shadowNodeWrapperToShadowNodeWrapperId = new Map<any, number>();
 
-let rootNode: Node | undefined = undefined;
+let rootNode: Node | undefined;
 
 let visited = new Set<any>();
 
 function getRefChecker(name: string) {
   return (ref: any) => {
-    console.log('equality check', ref === ref.getScrollResponder());
-
     refId = 1;
     foundRefToId = new Map<any, number>();
 
@@ -240,7 +221,7 @@ function comparator(node: Node) {
   const derivedRef = ref._componentRef;
   if (derivedRef) {
     if (foundRefToId.has(derivedRef)) {
-      node['_componentRef'] = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
+      node._componentRef = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
     } else {
       const id = refId++;
       foundRefToId.set(derivedRef, id);
@@ -298,8 +279,9 @@ function printNode(node: Node | number | string, prop?: string) {
   increaseIndent();
 
   printableProps.forEach((key) => {
-    if (node[key]) {
-      printNode(node[key], key);
+    const value = node[key];
+    if (value) {
+      printNode(value, key);
     }
   });
 
@@ -365,7 +347,6 @@ function checkFindNodeHandle(node: Node) {
     node['findNodeHandle()'] = `"TAG ${id}"`;
   } catch {
     node['findNodeHandle()'] = '"ERROR"';
-    return;
   }
 }
 
@@ -458,6 +439,14 @@ function findNativeStateObjects(node: Node, ref: any, source: string = '') {
 }
 
 export default function InstanceDiscoveryExample() {
+  if (!isFabric()) {
+    return (
+      <Text style={styles.notSupportedText}>
+        This example works only on Fabric (the New Architecture)
+      </Text>
+    );
+  }
+
   return (
     <>
       <Text style={styles.headingText}>
@@ -549,10 +538,6 @@ export default function InstanceDiscoveryExample() {
         stroke="purple"
         strokeWidth="1"
       />
-      <FlatListWithCustomRenderer
-        ref={getRefChecker('FlatListWithCustomRenderer')}
-        data={[]}
-      />
     </>
   );
 }
@@ -562,6 +547,12 @@ const styles = StyleSheet.create({
     marginTop: 20,
     fontSize: 20,
     fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  notSupportedText: {
+    marginTop: 20,
+    marginHorizontal: 20,
+    fontSize: 16,
     textAlign: 'center',
   },
 });

--- a/apps/common-app/src/examples/InstanceDiscoveryExample.tsx
+++ b/apps/common-app/src/examples/InstanceDiscoveryExample.tsx
@@ -1,7 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-inline-styles/no-inline-styles */
-/* eslint-disable no-useless-constructor */
-/* eslint-disable camelcase */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { FlashList } from '@shopify/flash-list';
 import {
   ActivityIndicator,
@@ -16,7 +17,6 @@ import {
   RefreshControl,
   ScrollView,
   SectionList,
-  StyleSheet,
   Switch,
   Text,
   TextInput,
@@ -26,33 +26,50 @@ import {
   // TouchableWithoutFeedback,
   View,
   VirtualizedList,
+  StyleSheet,
+  type ScrollViewProps,
 } from 'react-native';
 import { ScrollView as RNGHScrollView } from 'react-native-gesture-handler';
-import { makeMutable } from 'react-native-reanimated';
 import { Path as RNSVGPath } from 'react-native-svg';
+import { makeMutable } from 'react-native-reanimated';
+// @ts-expect-error No types for deep import.
+import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
+import { useCallback } from 'react';
 
-function isFabric(): boolean {
-  return !!(global as Record<string, unknown>)._IS_FABRIC;
-}
-
-// Conditionally import ReactFabric only on Fabric architecture
-let ReactFabric: any = null;
-if (isFabric()) {
-  try {
-    ReactFabric = require('react-native/Libraries/Renderer/shims/ReactFabric');
-  } catch {
-    // ReactFabric not available
-  }
-}
-
-const findHostInstance_DEPRECATED =
-  ReactFabric?.findHostInstance_DEPRECATED as (ref: any) => any;
+const findHostInstance_DEPRECATED = ReactFabric.findHostInstance_DEPRECATED as (
+  ref: any
+) => any;
 
 // Make sure Reanimated and Worklets are initialized.
 makeMutable(() => {
   'worklet';
   return undefined;
 });
+
+const CustomScrollComponent = (props: ScrollViewProps) => (
+  <View>
+    <ScrollView {...props} />
+  </View>
+);
+
+function FlatListWithCustomRenderer({ data, ref }: { data: any[]; ref: any }) {
+  const renderItem = useCallback((info: any) => {
+    return <Text>{info.item}</Text>;
+  }, []);
+
+  const renderScrollComponent = useCallback((props: ScrollViewProps) => {
+    return <CustomScrollComponent {...props} />;
+  }, []);
+
+  return (
+    <FlatList
+      data={data}
+      ref={ref}
+      renderItem={renderItem}
+      renderScrollComponent={renderScrollComponent}
+    />
+  );
+}
 
 type ImperativeShadowNodeWrapper = {
   source: string;
@@ -74,7 +91,6 @@ class Node {
   ['getScrollRef()']?: string | Node;
   ['__internalInstanceHandle']?: string | Node;
   ['findHostInstance_DEPRECATED()']?: string | Node;
-  ['_hasAnimatedRef']?: string;
   ['_componentRef']?: string | Node;
   ['stateNode.node']?: string | Node;
   ['shadowNodeWrapper']?: string;
@@ -92,12 +108,14 @@ let handleToHandleId = new Map<number, number>();
 let shadowNodeWrapperId = 1;
 let shadowNodeWrapperToShadowNodeWrapperId = new Map<any, number>();
 
-let rootNode: Node | undefined;
+let rootNode: Node | undefined = undefined;
 
 let visited = new Set<any>();
 
 function getRefChecker(name: string) {
   return (ref: any) => {
+    console.log('equality check', ref === ref.getScrollResponder());
+
     refId = 1;
     foundRefToId = new Map<any, number>();
 
@@ -219,23 +237,18 @@ function comparator(node: Node) {
     }
   }
 
-  if (ref._hasAnimatedRef) {
-    node._hasAnimatedRef = '"YES"';
-    const derivedRef = ref._componentRef;
-    if (derivedRef) {
-      if (foundRefToId.has(derivedRef)) {
-        node._componentRef = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
-      } else {
-        const id = refId++;
-        foundRefToId.set(derivedRef, id);
-        const propName = '_componentRef';
-        const derivedSource = `${source}.${propName}`;
-        const newNode = new Node(id, derivedSource, derivedRef);
-        node[propName] = newNode;
-        nodesToCheck.push(newNode);
-      }
+  const derivedRef = ref._componentRef;
+  if (derivedRef) {
+    if (foundRefToId.has(derivedRef)) {
+      node['_componentRef'] = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
     } else {
-      node._componentRef = '"NO"';
+      const id = refId++;
+      foundRefToId.set(derivedRef, id);
+      const propName = '_componentRef';
+      const derivedSource = `${source}.${propName}`;
+      const newNode = new Node(id, derivedSource, derivedRef);
+      node[propName] = newNode;
+      nodesToCheck.push(newNode);
     }
   }
 }
@@ -249,7 +262,6 @@ const printableProps = [
   'getNativeScrollRef()',
   'getScrollRef()',
   '__internalInstanceHandle',
-  '_hasAnimatedRef',
   '_componentRef',
   'findHostInstance_DEPRECATED()',
   'stateNode.node',
@@ -286,9 +298,8 @@ function printNode(node: Node | number | string, prop?: string) {
   increaseIndent();
 
   printableProps.forEach((key) => {
-    const value = node[key];
-    if (value) {
-      printNode(value, key);
+    if (node[key]) {
+      printNode(node[key], key);
     }
   });
 
@@ -354,6 +365,7 @@ function checkFindNodeHandle(node: Node) {
     node['findNodeHandle()'] = `"TAG ${id}"`;
   } catch {
     node['findNodeHandle()'] = '"ERROR"';
+    return;
   }
 }
 
@@ -446,14 +458,6 @@ function findNativeStateObjects(node: Node, ref: any, source: string = '') {
 }
 
 export default function InstanceDiscoveryExample() {
-  if (!isFabric()) {
-    return (
-      <Text style={styles.notSupportedText}>
-        This example works only on Fabric (the New Architecture)
-      </Text>
-    );
-  }
-
   return (
     <>
       <Text style={styles.headingText}>
@@ -545,6 +549,10 @@ export default function InstanceDiscoveryExample() {
         stroke="purple"
         strokeWidth="1"
       />
+      <FlatListWithCustomRenderer
+        ref={getRefChecker('FlatListWithCustomRenderer')}
+        data={[]}
+      />
     </>
   );
 }
@@ -554,12 +562,6 @@ const styles = StyleSheet.create({
     marginTop: 20,
     fontSize: 20,
     fontWeight: 'bold',
-    textAlign: 'center',
-  },
-  notSupportedText: {
-    marginTop: 20,
-    marginHorizontal: 20,
-    fontSize: 16,
     textAlign: 'center',
   },
 });

--- a/apps/common-app/src/examples/InstanceDiscoveryExample.web.tsx
+++ b/apps/common-app/src/examples/InstanceDiscoveryExample.web.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable no-useless-constructor */
+/* eslint-disable no-inline-styles/no-inline-styles */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { FlashList } from '@shopify/flash-list';
 import {
   ActivityIndicator,
@@ -15,6 +14,7 @@ import {
   RefreshControl,
   ScrollView,
   SectionList,
+  StyleSheet,
   Switch,
   Text,
   TextInput,
@@ -24,11 +24,10 @@ import {
   // TouchableWithoutFeedback,
   View,
   VirtualizedList,
-  StyleSheet,
 } from 'react-native';
 import { ScrollView as RNGHScrollView } from 'react-native-gesture-handler';
-import { Path as RNSVGPath } from 'react-native-svg';
 import { makeMutable } from 'react-native-reanimated';
+import SVG, { Path as RNSVGPath } from 'react-native-svg';
 
 // Make sure Reanimated and Worklets are initialized.
 makeMutable(() => {
@@ -59,7 +58,7 @@ class Node {
 let refId = 1;
 let foundRefToId = new Map<any, number>();
 
-let rootNode: Node | undefined = undefined;
+let rootNode: Node | undefined;
 
 function getRefChecker(name: string) {
   return (ref: any) => {
@@ -157,7 +156,7 @@ function comparator(node: Node) {
   const derivedRef = ref._componentRef;
   if (derivedRef) {
     if (foundRefToId.has(derivedRef)) {
-      node['_componentRef'] = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
+      node._componentRef = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
     } else {
       const id = refId++;
       foundRefToId.set(derivedRef, id);
@@ -220,8 +219,9 @@ function printNode(node: Node | number | string, prop?: string) {
   increaseIndent();
 
   printableProps.forEach((key) => {
-    if (node[key]) {
-      printNode(node[key], key);
+    const value = node[key];
+    if (value) {
+      printNode(value, key);
     }
   });
 
@@ -314,13 +314,15 @@ export default function InstanceDiscoveryExample() {
       <RNGHScrollView ref={getRefChecker('RNGHScrollView')}>
         <Text>RNGH ScrollView Content</Text>
       </RNGHScrollView>
-      <RNSVGPath
-        ref={getRefChecker('SVG Path')}
-        d="M150 0 L75 200 L225 200 Z"
-        fill="lime"
-        stroke="purple"
-        strokeWidth="1"
-      />
+      <SVG>
+        <RNSVGPath
+          ref={getRefChecker('SVG Path')}
+          d="M150 0 L75 200 L225 200 Z"
+          fill="lime"
+          stroke="purple"
+          strokeWidth="1"
+        />
+      </SVG>
     </>
   );
 }

--- a/apps/common-app/src/examples/InstanceDiscoveryExample.web.tsx
+++ b/apps/common-app/src/examples/InstanceDiscoveryExample.web.tsx
@@ -1,6 +1,7 @@
-/* eslint-disable no-useless-constructor */
-/* eslint-disable no-inline-styles/no-inline-styles */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { FlashList } from '@shopify/flash-list';
 import {
   ActivityIndicator,
@@ -14,7 +15,6 @@ import {
   RefreshControl,
   ScrollView,
   SectionList,
-  StyleSheet,
   Switch,
   Text,
   TextInput,
@@ -24,10 +24,11 @@ import {
   // TouchableWithoutFeedback,
   View,
   VirtualizedList,
+  StyleSheet,
 } from 'react-native';
 import { ScrollView as RNGHScrollView } from 'react-native-gesture-handler';
+import { Path as RNSVGPath } from 'react-native-svg';
 import { makeMutable } from 'react-native-reanimated';
-import SVG, { Path as RNSVGPath } from 'react-native-svg';
 
 // Make sure Reanimated and Worklets are initialized.
 makeMutable(() => {
@@ -50,7 +51,6 @@ class Node {
   ['scrollTo()']?: string;
   ['__internalInstanceHandle']?: string | Node;
   ['findHostInstance_DEPRECATED()']?: string | Node;
-  ['_hasAnimatedRef']?: string;
   ['_componentRef']?: string | Node;
   ['stateNode.node']?: string | Node;
   ['_reactInternals']?: string | undefined;
@@ -59,7 +59,7 @@ class Node {
 let refId = 1;
 let foundRefToId = new Map<any, number>();
 
-let rootNode: Node | undefined;
+let rootNode: Node | undefined = undefined;
 
 function getRefChecker(name: string) {
   return (ref: any) => {
@@ -154,23 +154,18 @@ function comparator(node: Node) {
     }
   }
 
-  if (ref._hasAnimatedRef) {
-    node._hasAnimatedRef = '"YES"';
-    const derivedRef = ref._componentRef;
-    if (derivedRef) {
-      if (foundRefToId.has(derivedRef)) {
-        node._componentRef = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
-      } else {
-        const id = refId++;
-        foundRefToId.set(derivedRef, id);
-        const propName = '_componentRef';
-        const derivedSource = `${source}.${propName}`;
-        const newNode = new Node(id, derivedSource, derivedRef);
-        node[propName] = newNode;
-        nodesToCheck.push(newNode);
-      }
+  const derivedRef = ref._componentRef;
+  if (derivedRef) {
+    if (foundRefToId.has(derivedRef)) {
+      node['_componentRef'] = `"OBJECT ${foundRefToId.get(derivedRef)}"`;
     } else {
-      node._componentRef = '"NO"';
+      const id = refId++;
+      foundRefToId.set(derivedRef, id);
+      const propName = '_componentRef';
+      const derivedSource = `${source}.${propName}`;
+      const newNode = new Node(id, derivedSource, derivedRef);
+      node[propName] = newNode;
+      nodesToCheck.push(newNode);
     }
   }
 }
@@ -192,7 +187,6 @@ const printableProps = [
   'getScrollRef()',
   'scrollTo()',
   '__internalInstanceHandle',
-  '_hasAnimatedRef',
   '_componentRef',
   'stateNode.node',
   '_reactInternals',
@@ -226,9 +220,8 @@ function printNode(node: Node | number | string, prop?: string) {
   increaseIndent();
 
   printableProps.forEach((key) => {
-    const value = node[key];
-    if (value) {
-      printNode(value, key);
+    if (node[key]) {
+      printNode(node[key], key);
     }
   });
 
@@ -321,15 +314,13 @@ export default function InstanceDiscoveryExample() {
       <RNGHScrollView ref={getRefChecker('RNGHScrollView')}>
         <Text>RNGH ScrollView Content</Text>
       </RNGHScrollView>
-      <SVG>
-        <RNSVGPath
-          ref={getRefChecker('SVG Path')}
-          d="M150 0 L75 200 L225 200 Z"
-          fill="lime"
-          stroke="purple"
-          strokeWidth="1"
-        />
-      </SVG>
+      <RNSVGPath
+        ref={getRefChecker('SVG Path')}
+        d="M150 0 L75 200 L225 200 Z"
+        fill="lime"
+        stroke="purple"
+        strokeWidth="1"
+      />
     </>
   );
 }

--- a/packages/react-native-reanimated/__tests__/findHostInstance.test.ts
+++ b/packages/react-native-reanimated/__tests__/findHostInstance.test.ts
@@ -1,0 +1,45 @@
+/* eslint-disable camelcase */
+import type { IAnimatedComponentInternal } from '../src/createAnimatedComponent/commonTypes';
+import { findHostInstance } from '../src/platform-specific/findHostInstance';
+
+jest.mock('react-native/Libraries/Renderer/shims/ReactFabric', () => ({
+  findHostInstance_DEPRECATED: jest.fn(),
+}));
+
+const ReactFabric: { findHostInstance_DEPRECATED: jest.Mock } =
+  jest.requireMock('react-native/Libraries/Renderer/shims/ReactFabric');
+
+describe('findHostInstance', () => {
+  beforeEach(() => {
+    ReactFabric.findHostInstance_DEPRECATED.mockReset();
+  });
+
+  test('uses the resolved component ref when the fast path cannot handle it', () => {
+    const componentRef = { __nativeTag: 42 };
+    const hostInstance = { host: true };
+    const animatedComponent = {
+      _componentRef: componentRef,
+    } as unknown as IAnimatedComponentInternal;
+
+    ReactFabric.findHostInstance_DEPRECATED.mockReturnValue(hostInstance);
+
+    expect(findHostInstance(animatedComponent)).toBe(hostInstance);
+    expect(ReactFabric.findHostInstance_DEPRECATED).toHaveBeenCalledWith(
+      componentRef
+    );
+  });
+
+  test('uses the fast path for React Native 0.83 host instances', () => {
+    const hostInstance = {
+      __internalInstanceHandle: {},
+      __nativeTag: 42,
+      __viewConfig: { uiViewClassName: 'RCTView' },
+    };
+    const animatedComponent = {
+      _componentRef: hostInstance,
+    } as unknown as IAnimatedComponentInternal;
+
+    expect(findHostInstance(animatedComponent)).toBe(hostInstance);
+    expect(ReactFabric.findHostInstance_DEPRECATED).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -122,7 +122,6 @@ export interface IAnimatedComponentInternal {
   jestAnimatedProps: { value: AnimatedProps };
   _componentRef: AnimatedComponentRef | HTMLElement | null;
   _sharedElementTransition: SharedTransition | null;
-  _hasAnimatedRef: boolean;
   _jsPropsUpdater: IJSPropsUpdater;
   _InlinePropManager: IInlinePropManager;
   _PropsFilter: IPropsFilter;

--- a/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/createAnimatedComponent.tsx
@@ -160,7 +160,6 @@ export function createAnimatedComponent(
     jestAnimatedStyle: { value: StyleProps } = { value: {} };
     jestAnimatedProps: { value: AnimatedProps } = { value: {} };
     _componentRef: AnimatedComponentRef | HTMLElement | null = null;
-    _hasAnimatedRef = false;
     // Used only on web
     _componentDOMRef: HTMLElement | null = null;
     _sharedElementTransition: SharedTransition | null = null;
@@ -680,7 +679,6 @@ export function createAnimatedComponent(
       // Component can specify ref which should be animated when animated version of the component is created.
       // Otherwise, we animate the component itself.
       if (componentRef && componentRef.getAnimatableRef) {
-        this._hasAnimatedRef = true;
         return componentRef.getAnimatableRef();
       }
       // Case for SVG components on Web

--- a/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
@@ -34,9 +34,12 @@ function getViewInfo73(element: any) {
 }
 
 function getViewInfoLatest(element: any) {
+  // ReactNativeElement uses `__viewConfig`, while legacy
+  // ReactFabricHostComponent implementations expose `_viewConfig`.
+  const viewConfig = element?.__viewConfig ?? element?._viewConfig;
   return {
-    viewName: element?.__viewConfig?.uiViewClassName,
+    viewName: viewConfig?.uiViewClassName,
     viewTag: element?.__nativeTag,
-    viewConfig: element?.__viewConfig,
+    viewConfig,
   };
 }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/getViewInfo.ts
@@ -35,8 +35,8 @@ function getViewInfo73(element: any) {
 
 function getViewInfoLatest(element: any) {
   return {
-    viewName: element?._viewConfig?.uiViewClassName,
+    viewName: element?.__viewConfig?.uiViewClassName,
     viewTag: element?.__nativeTag,
-    viewConfig: element?._viewConfig,
+    viewConfig: element?.__viewConfig,
   };
 }

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -9,6 +9,8 @@ type HostInstanceFabric = {
   __internalInstanceHandle?: Record<string, unknown>;
   __nativeTag?: number;
   __viewConfig?: Record<string, unknown>;
+  // Legacy ReactFabricHostComponent key (e.g. react-native-macos).
+  _viewConfig?: Record<string, unknown>;
 };
 
 type HostInstancePaper = {
@@ -25,7 +27,9 @@ function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
   if (
     maybeNativeRef.__internalInstanceHandle &&
     maybeNativeRef.__nativeTag &&
-    maybeNativeRef.__viewConfig
+    // ReactFabricHostComponent (e.g. react-native-macos) exposes `_viewConfig`;
+    // ReactNativeElement uses `__viewConfig`.
+    (maybeNativeRef.__viewConfig || maybeNativeRef._viewConfig)
   ) {
     // This is a native ref to a Fabric component
     return maybeNativeRef;

--- a/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
+++ b/packages/react-native-reanimated/src/platform-specific/findHostInstance.ts
@@ -4,12 +4,11 @@
 import type { InternalHostInstance } from '../commonTypes';
 import type { IAnimatedComponentInternal } from '../createAnimatedComponent/commonTypes';
 import { ReanimatedError } from '../errors';
-import { isFabric } from '../PlatformChecker';
 
 type HostInstanceFabric = {
   __internalInstanceHandle?: Record<string, unknown>;
   __nativeTag?: number;
-  _viewConfig?: Record<string, unknown>;
+  __viewConfig?: Record<string, unknown>;
 };
 
 type HostInstancePaper = {
@@ -26,7 +25,7 @@ function findHostInstanceFastPath(maybeNativeRef: HostInstance | undefined) {
   if (
     maybeNativeRef.__internalInstanceHandle &&
     maybeNativeRef.__nativeTag &&
-    maybeNativeRef._viewConfig
+    maybeNativeRef.__viewConfig
   ) {
     // This is a native ref to a Fabric component
     return maybeNativeRef;
@@ -73,13 +72,11 @@ export function findHostInstance(
   resolveFindHostInstance_DEPRECATED();
   /*
     The Fabric implementation of `findHostInstance_DEPRECATED` requires a React ref as an argument
-    rather than a native ref. If a component implements the `getAnimatableRef` method, it must use 
-    the ref provided by this method. It is the component's responsibility to ensure that this is 
-    a valid React ref.
+    rather than a native ref. Prefer the resolved component ref when available so components can
+    forward their ref to the host view that should be animated. Components that expose an animatable
+    ref via `getAnimatableRef` already have it resolved into `_componentRef`.
   */
   return findHostInstance_DEPRECATED(
-    !isFabric() || (component as IAnimatedComponentInternal)._hasAnimatedRef
-      ? (component as IAnimatedComponentInternal)._componentRef
-      : component
+    (component as IAnimatedComponentInternal)._componentRef ?? component
   );
 }


### PR DESCRIPTION
## Description

React Native 0.86 exposes Fabric host view configuration through `ReactNativeElement.__viewConfig`, while this Reanimated 3.19 fork only reads the legacy `_viewConfig` field. That prevents `adaptViewConfig` from registering component attributes, leaving `animatablePropNames_` at its built-in set and routing custom props such as SVG `fill` through the JS fallback path.

This ports the upstream host-instance fixes so RN 0.86 uses `__viewConfig`, legacy renderers remain supported through `_viewConfig`, and components that provide an animatable ref resolve the intended host instance.

Upstream commits ported onto the 3.19 fork:
- [`5587b9a`](https://github.com/software-mansion/react-native-reanimated/commit/5587b9a02a7f88b97ee1d788f8289e3db78ce55f) — Prefer resolved component ref for host lookup ([#9589](https://github.com/software-mansion/react-native-reanimated/pull/9589))
- [`3296341`](https://github.com/software-mansion/react-native-reanimated/commit/32963413c3b92aa7ee27854483a6108c9c34fe95) — Support legacy `_viewConfig` for RN < 0.86 ([#9680](https://github.com/software-mansion/react-native-reanimated/pull/9680))

> [!NOTE]
> The upstream commits target a newer Reanimated layout. Their behavior and tests were adapted to the 3.19 fork, with unrelated newer example changes excluded.

## Test steps

1. Run `yarn workspace react-native-reanimated test findHostInstance.test.ts --runInBand` after installing repository dependencies.
2. Build Discord against this fork on RN 0.86.
3. Start a voice-message recording and speak continuously; verify the animated SVG ellipse remains blurple instead of flickering red.
4. Verify an animated SVG component registers its `validAttributes`, including `fill`, through `adaptViewConfig`.

> [!NOTE]
> The targeted test was not run locally because this checkout does not have its dependencies installed. IDE lint diagnostics and `git diff --check` pass.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216245486036040